### PR TITLE
docs(profile): fix reviewer route links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,7 +27,7 @@ Public surfaces route reviewers to proof records and validation artifacts. Rende
 3. Review [hawkinsoperations-validation](https://github.com/HawkinsOperations/hawkinsoperations-validation) - synthetic validation outputs.
 4. Review [hawkinsoperations-platform](https://github.com/HawkinsOperations/hawkinsoperations-platform) - HO-DET-001 runtime-contract guardrail.
 5. Review [hawkinsoperations-detections](https://github.com/HawkinsOperations/hawkinsoperations-detections) - source logic.
-6. Use [START_HERE.md](./profile/START_HERE.md) / [repo authority map](./architecture/REPO_AUTHORITY_MAP.md) for deeper routing.
+6. Use [START_HERE.md](./START_HERE.md) / [repo authority map](../architecture/REPO_AUTHORITY_MAP.md) for deeper routing.
 
 ## System surfaces
 


### PR DESCRIPTION
Summary:
- Fixes reviewer-route links in the HawkinsOperations organization profile.
- Preserves the current HO-DET-001 public ceiling.

Claim boundary:
- HO-DET-001 remains TEST_VALIDATED_SYNTHETIC_SCOPE.
- This PR does not prove runtime-active, signal-observed, evidence-linked public proof, public-safe status, production-ready status, fleet-wide coverage, Cribl-routed status, Wazuh-routed status, AWS-live status, HO-GPU-01 runtime-active status, autonomous SOC operation, AI-approved disposition, or analyst-approved disposition.
- Website rendering and reviewer routing are not proof.

Validation:
- git diff --cached --check passed before commit.
- Commit created locally as d018867d400f5c5f479927f119bf034f39747928.
- No private path, LAN IP, token, password, key value, or raw evidence was included.