### PR TITLE
Update org landing reviewer route

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,84 +2,75 @@
 
 # HawkinsOperations Detection Engineering SOC
 
-Governed detection engineering and AI-assisted SOC production.
+Governed detection engineering, SOC automation, and AI-assisted security operations with proof-bound claims.
 
-HawkinsOperations speeds up security production without letting the system lie.
+**Current public proof ceiling:** `TEST_VALIDATED_SYNTHETIC_SCOPE`
 
-Public surfaces route reviewers to proof records and validation artifacts. Rendering is not proof.
+## What This Is
 
-| Surface | Current role |
+HawkinsOperations separates source, validation, runtime, signal, evidence, and public proof so security work can move faster without letting claims drift.
+
+## Current Flagship Proof Boundary
+
+**HO-DET-001** is the current flagship reviewer path. The public ceiling remains `TEST_VALIDATED_SYNTHETIC_SCOPE` unless a separate runtime and Splunk evidence lane proves a new ceiling through promotion gates.
+
+| Boundary Item | Current State |
 |---|---|
-| Current public ceiling | `TEST_VALIDATED_SYNTHETIC_SCOPE` |
-| Website | Reviewer routing / public rendering only |
-| Proof repo | Proof records and bounded case studies |
-| Validation repo | Synthetic validation outputs |
-| Platform repo | Runtime-contract guardrails, not runtime proof |
-| AI role | Support-only labor, not disposition authority |
-| Authority | Deterministic checks, CI, proof records, human promotion gates |
+| HO-DET-001 source | Source exists |
+| Splunk source | Source exists |
+| Controlled synthetic validation | Passed within recorded synthetic scope |
+| Platform runtime contract guardrail | Exists as non-promotional contract enforcement |
+| Runtime, signal, and public-safe status | Blocked until evidence promotion |
 
-![Reviewer route](./assets/reviewer-route.svg)
+## Reviewer Route
 
-## 3-minute reviewer route
+<p>
+  <a href="https://hawkinsoperations.com/"><strong>hawkinsoperations.com</strong></a>
+  &nbsp;|&nbsp;
+  <a href="https://github.com/HawkinsOperations/hawkinsoperations-proof"><strong>proof repo</strong></a>
+  &nbsp;|&nbsp;
+  <a href="https://github.com/HawkinsOperations/hawkinsoperations-validation"><strong>validation repo</strong></a>
+  &nbsp;|&nbsp;
+  <a href="https://github.com/HawkinsOperations/hawkinsoperations-detections"><strong>detections repo</strong></a>
+</p>
 
-1. Start with [hawkinsoperations.com](https://hawkinsoperations.com/) - public reviewer surface.
-2. Review [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof) - proof records and case studies.
-3. Review [hawkinsoperations-validation](https://github.com/HawkinsOperations/hawkinsoperations-validation) - synthetic validation outputs.
-4. Review [hawkinsoperations-platform](https://github.com/HawkinsOperations/hawkinsoperations-platform) - HO-DET-001 runtime-contract guardrail.
-5. Review [hawkinsoperations-detections](https://github.com/HawkinsOperations/hawkinsoperations-detections) - source logic.
-6. Use [START_HERE.md](./START_HERE.md) / [repo authority map](../architecture/REPO_AUTHORITY_MAP.md) for deeper routing.
+## System Map
 
-## System surfaces
+![Truth surface flow](./assets/truth-surface-flow.svg)
 
-| Plane | Repo / Surface | Owns | Does not prove by itself |
-|---|---|---|---|
-| <img src="./assets/source-plane.svg" width="28" alt=""> Source | [hawkinsoperations-detections](https://github.com/HawkinsOperations/hawkinsoperations-detections) | Detection source truth | Runtime firing, signal observation |
-| <img src="./assets/validation-plane.svg" width="28" alt=""> Validation | [hawkinsoperations-validation](https://github.com/HawkinsOperations/hawkinsoperations-validation) | Synthetic validation truth | Production/live signal |
-| <img src="./assets/runtime-plane.svg" width="28" alt=""> Runtime | [hawkinsoperations-platform](https://github.com/HawkinsOperations/hawkinsoperations-platform) | Runtime/orchestration contracts | Public proof without evidence records |
-| <img src="./assets/signal-plane.svg" width="28" alt=""> Signal | Runtime and telemetry records | Observed signal context when records support it | Public proof or promotion by itself |
-| <img src="./assets/evidence-plane.svg" width="28" alt=""> Evidence | [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Proof records and case studies | Raw private runtime state |
-| <img src="./assets/public-proof-plane.svg" width="28" alt=""> Public Proof | [hawkinsoperations-website](https://github.com/HawkinsOperations/hawkinsoperations-website) | Public rendering and reviewer route | Proof authority |
-| <img src="./assets/claim-firewall.svg" width="28" alt=""> Governance | `.github` | Governance and reviewer routing | Detection/runtime/evidence truth |
+`Source` → `Validation` → `Runtime Contract` → `Evidence` → `Public Rendering`
 
-## Flagship proof boundary
+| Surface | Owns | Boundary |
+|---|---|---|
+| `hawkinsoperations-detections` | Detections source truth | Source exists does not prove runtime firing |
+| `hawkinsoperations-validation` | Behavior and CI truth | Synthetic pass does not prove live signal |
+| `hawkinsoperations-platform` | Runtime contract guardrails | Contract enforcement is not public proof |
+| `hawkinsoperations-proof` | Evidence records and proof boundaries | Evidence requires review before public-safe use |
+| `hawkinsoperations-website` | Public rendering and reviewer route | Website rendering is not proof |
+| `.github` | Reviewer routing and governance front door | GitHub rendering is not proof |
 
-![Proof ceiling badge](./assets/proof-ceiling-badge.svg)
+## Supported Vs Blocked
 
-HO-DET-001 is the current flagship proof path.
-Its public ceiling is synthetic validation scope where records support it.
-Source and validation artifacts are separated from runtime, signal, evidence, and public proof.
-Platform runtime contract enforcement exists for HO-DET-001 and preserves the public ceiling at `TEST_VALIDATED_SYNTHETIC_SCOPE`.
-This is a non-promotional guardrail. It does not prove runtime-active status, signal-observed public proof, public-safe runtime proof, live Splunk fired, Cribl-routed status, Wazuh-routed public proof, production-ready status, fleet-wide coverage, AWS-live status, autonomous SOC operation, AI-approved disposition, or analyst-approved disposition.
-Stronger claims require separate evidence-backed promotion.
-
-## Supported vs blocked claims
-
-| Supported | Blocked / not claimed |
+| Supported | Blocked / Not Claimed |
 |---|---|
-| bounded public reviewer surface | production-ready |
-| separated truth surfaces | fleet-wide |
-| synthetic validation public ceiling where records support it | runtime-active |
-| proof-bound claim promotion model | signal-observed |
-| AI support-only boundary | public-safe runtime proof |
+| Source exists | runtime-active |
+| Synthetic validation passed | signal-observed |
+| Proof-bound reviewer surface | public-safe |
+| CI/check-enforced validation scope | production-ready |
+| Support-only AI boundary | fleet-wide |
 |  | autonomous SOC |
+|  | Cribl/Wazuh/AWS-live |
 |  | AI-approved disposition |
-|  | Cribl-routed |
-|  | Wazuh-routed |
-|  | AWS-live |
-|  | enterprise deployed |
+|  | live Splunk fired as public proof |
 
-## Claim firewall
+## Next Gate
 
-![Claim firewall](./assets/claim-firewall.svg)
+Next gate: controlled runtime evidence packet → sanitized case packet → deterministic verifier → proof record update.
 
-GitHub rendering is not proof.
-Website rendering is not proof.
-Proof records, validation artifacts, deterministic checks, CI, and explicit promotion gates own authority.
+This gate is not already complete. It must land through the separate runtime/Splunk lane before the public ceiling can change.
 
-Current public ceiling remains `TEST_VALIDATED_SYNTHETIC_SCOPE` unless explicitly promoted by proof records.
+## Doctrine
 
-## Legacy boundary
+**AI is labor. Governance is authority.**
 
-HawkinsOps / hawkinsops.com is legacy/reference unless explicitly promoted by current HawkinsOperations proof records. Current claims live under HawkinsOperations proof boundaries.
-
-Build loud. Verify hard. Claim tight. Ship receipts.
+**Build loud. Verify hard. Claim tight. Ship receipts.**

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,6 +6,8 @@ Governed detection engineering, SOC automation, and AI-assisted security operati
 
 **Current public proof ceiling:** `TEST_VALIDATED_SYNTHETIC_SCOPE`
 
+HawkinsOperations speeds up security production without letting the system lie.
+
 ## What This Is
 
 HawkinsOperations separates source, validation, runtime, signal, evidence, and public proof so security work can move faster without letting claims drift.
@@ -49,6 +51,12 @@ HawkinsOperations separates source, validation, runtime, signal, evidence, and p
 | `hawkinsoperations-website` | Public rendering and reviewer route | Website rendering is not proof |
 | `.github` | Reviewer routing and governance front door | GitHub rendering is not proof |
 
+## Real Controls
+
+Docs, README files, issue cards, architecture maps, and diagrams are not real controls by themselves.
+
+A control becomes real only when it blocks, fails, or forces correction through CI, branch protection, required checks, deterministic verifiers, typed claim gates, or another blocking mechanism.
+
 ## Supported Vs Blocked
 
 | Supported | Blocked / Not Claimed |
@@ -58,9 +66,12 @@ HawkinsOperations separates source, validation, runtime, signal, evidence, and p
 | Proof-bound reviewer surface | public-safe |
 | CI/check-enforced validation scope | production-ready |
 | Support-only AI boundary | fleet-wide |
+|  | Cribl-routed |
+|  | Wazuh-routed |
+|  | AWS-live |
 |  | autonomous SOC |
-|  | Cribl/Wazuh/AWS-live |
 |  | AI-approved disposition |
+|  | analyst-approved disposition |
 |  | live Splunk fired as public proof |
 
 ## Next Gate
@@ -68,6 +79,12 @@ HawkinsOperations separates source, validation, runtime, signal, evidence, and p
 Next gate: controlled runtime evidence packet → sanitized case packet → deterministic verifier → proof record update.
 
 This gate is not already complete. It must land through the separate runtime/Splunk lane before the public ceiling can change.
+
+## Legacy Boundary
+
+HawkinsOps / hawkinsops.com is legacy/reference unless explicitly promoted by current HawkinsOperations proof records.
+
+Current claims live under HawkinsOperations proof boundaries.
 
 ## Doctrine
 

--- a/profile/assets/hawkinsoperations-banner.svg
+++ b/profile/assets/hawkinsoperations-banner.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="360" viewBox="0 0 1280 360" role="img" aria-labelledby="title desc">
   <title id="title">HawkinsOperations Detection Engineering SOC</title>
-  <desc id="desc">A dark editorial banner showing the proof route from source through public proof, bounded by TEST_VALIDATED_SYNTHETIC_SCOPE.</desc>
+  <desc id="desc">A dark command-center banner showing the proof-bound route from source through public rendering, bounded by TEST_VALIDATED_SYNTHETIC_SCOPE.</desc>
   <rect width="1280" height="360" fill="#080b10"/>
   <rect x="28" y="28" width="1224" height="304" rx="18" fill="#0c1118" stroke="#2b3542"/>
   <path d="M68 92 H1212" stroke="#253241" stroke-width="1"/>
   <path d="M68 268 H1212" stroke="#253241" stroke-width="1"/>
   <text x="68" y="86" fill="#d8dee8" font-family="Segoe UI, Arial, sans-serif" font-size="34" font-weight="700">HawkinsOperations Detection Engineering SOC</text>
-  <text x="68" y="124" fill="#8fd8ff" font-family="Segoe UI, Arial, sans-serif" font-size="18">Governed detection engineering and AI-assisted SOC production</text>
+  <text x="68" y="124" fill="#8fd8ff" font-family="Segoe UI, Arial, sans-serif" font-size="18">Governed detection engineering, SOC automation, and AI-assisted security operations</text>
   <text x="68" y="298" fill="#aeb9c6" font-family="Segoe UI, Arial, sans-serif" font-size="16">Website rendering is not proof</text>
   <g transform="translate(68 168)">
     <g fill="#0f1721" stroke="#6f7d8d" stroke-width="1.2">
@@ -35,7 +35,7 @@
       <text x="416" y="36">Runtime</text>
       <text x="615" y="36">Signal</text>
       <text x="805" y="36">Evidence</text>
-      <text x="976" y="36">Public Proof</text>
+      <text x="968" y="36">Public Rendering</text>
     </g>
   </g>
   <g transform="translate(842 72)">

--- a/profile/assets/truth-surface-flow.svg
+++ b/profile/assets/truth-surface-flow.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="220" viewBox="0 0 960 220" role="img" aria-labelledby="title desc">
+  <title id="title">HawkinsOperations truth surface flow</title>
+  <desc id="desc">A compact flow showing source, validation, runtime contract, evidence, and public rendering as separate truth surfaces.</desc>
+  <rect width="960" height="220" rx="14" fill="#080b10"/>
+  <rect x="18" y="18" width="924" height="184" rx="12" fill="#0d131b" stroke="#2b3542"/>
+  <g fill="#111a25" stroke="#6f7d8d" stroke-width="1.2">
+    <rect x="46" y="68" width="144" height="78" rx="8"/>
+    <rect x="230" y="68" width="144" height="78" rx="8"/>
+    <rect x="414" y="68" width="144" height="78" rx="8"/>
+    <rect x="598" y="68" width="144" height="78" rx="8"/>
+    <rect x="782" y="68" width="132" height="78" rx="8"/>
+  </g>
+  <g stroke="#8fd8ff" stroke-width="1.6" stroke-linecap="round" fill="none">
+    <path d="M190 107 H230"/>
+    <path d="M374 107 H414"/>
+    <path d="M558 107 H598"/>
+    <path d="M742 107 H782"/>
+    <path d="M221 100 L230 107 L221 114"/>
+    <path d="M405 100 L414 107 L405 114"/>
+    <path d="M589 100 L598 107 L589 114"/>
+    <path d="M773 100 L782 107 L773 114"/>
+  </g>
+  <g font-family="Segoe UI, Arial, sans-serif" text-anchor="middle">
+    <g fill="#d8dee8" font-size="17" font-weight="700">
+      <text x="118" y="98">Source</text>
+      <text x="302" y="98">Validation</text>
+      <text x="486" y="94">Runtime</text>
+      <text x="486" y="116">Contract</text>
+      <text x="670" y="98">Evidence</text>
+      <text x="848" y="94">Public</text>
+      <text x="848" y="116">Rendering</text>
+    </g>
+    <g fill="#93a4b5" font-size="12">
+      <text x="118" y="132">detections</text>
+      <text x="302" y="132">validation + CI</text>
+      <text x="486" y="132">platform guardrail</text>
+      <text x="670" y="132">proof records</text>
+      <text x="848" y="132">website + GitHub</text>
+    </g>
+  </g>
+  <text x="480" y="40" text-anchor="middle" fill="#8fd8ff" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700">TRUTH SURFACES STAY SEPARATE UNTIL PROMOTION GATES PASS</text>
+  <text x="480" y="178" text-anchor="middle" fill="#aeb9c6" font-family="Segoe UI, Arial, sans-serif" font-size="13">Rendering routes reviewers. It does not promote runtime, signal, evidence, or public-safe claims.</text>
+</svg>


### PR DESCRIPTION
This updates the HawkinsOperations organization profile landing page into a sharper reviewer-facing front door.

Changes:
- Rewrites the org landing around the current HawkinsOperations thesis: speed with enforcement.
- Adds clearer reviewer routes.
- Adds stronger truth-surface separation.
- Updates landing visuals for public rendering and proof-bound routing.
- Adds a compact truth-surface flow asset.

Claim boundary:
- Current public ceiling remains TEST_VALIDATED_SYNTHETIC_SCOPE.
- Website/GitHub rendering remains not proof.
- This PR does not promote runtime-active, signal-observed, public-safe, production-ready, fleet-wide, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, AI-approved disposition, analyst-approved disposition, or live Splunk fired as public proof.
- This is org-front-door routing polish only, not runtime proof, signal proof, proof-record promotion, or website proof authority.

Validation:
- git diff --check passed.
- staged diff check passed.
- private/local-path/secret scan passed.
- blocked-claim context scan passed.