### PR TITLE
docs(profile): clean org banner monogram

### DIFF
--- a/profile/assets/hawkinsoperations-banner.svg
+++ b/profile/assets/hawkinsoperations-banner.svg
@@ -101,16 +101,12 @@
 
     <!-- White H letter -->
     <g fill="url(#silver)">
-      <rect x="-46" y="-50" width="14" height="100" rx="1.5"/>
-      <rect x="-12" y="-50" width="14" height="100" rx="1.5"/>
-      <rect x="-46" y="-7" width="48" height="14"/>
+      <rect x="-54" y="-54" width="18" height="108" rx="2"/>
+      <rect x="18" y="-54" width="18" height="108" rx="2"/>
+      <rect x="-54" y="-8" width="90" height="16" rx="1"/>
     </g>
 
-    <!-- Hawk silhouette overlapping right of H -->
-    <path d="M -4 -4 Q 6 -24 28 -24 Q 50 -22 60 -4 L 80 -6 L 64 8 Q 58 22 36 24 Q 14 24 -4 18 Z" fill="#0B1428"/>
-
-    <!-- Hawk eye -->
-    <circle cx="40" cy="-10" r="1.8" fill="#3FC9FF" filter="url(#glow)"/>
+    <path d="M 42 -42 L 42 42" stroke="#3FC9FF" stroke-width="2" stroke-opacity="0.65" filter="url(#glow)"/>
   </g>
 
   <!-- Vertical separator -->


### PR DESCRIPTION
This is SVG-only visual polish. It removes the muddy hawk/blob overlay from the README banner. It preserves the profile README content, PR template, claim boundaries, and proof ceiling. Website/GitHub rendering remains non-proof. No runtime-active, signal-observed, public-safe, production, fleet-wide, autonomous SOC, Cribl-routed, Wazuh-routed, AWS-live, AI-approved, AI-decided, analyst-approved, or production AutoSOC claim is promoted.