### PR TITLE
docs(profile): align org README with reviewer cockpit

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,129 +4,155 @@
 
 # HawkinsOperations
 
-**Governed detection engineering and SOC automation**
+**Governed detection engineering · SOC automation · proof-routed claims**
 
-_AI generates work. Evidence and human review authorize claims._
+AI generates work. Evidence and human review authorize claims.
 
-`CONTROLLED_TEST_VALIDATED` &nbsp;&middot;&nbsp; `NOT_PUBLIC_SAFE` &nbsp;&middot;&nbsp; `HO-DET-001` &nbsp;&middot;&nbsp; `RENDERING_NOT_PROOF` &nbsp;&middot;&nbsp; `HUMAN_REVIEW_REQUIRED`
+HawkinsOperations is a governed SOC automation framework that separates generated work from authorized proof: detections, validation, case packets, AI support, deterministic checks, proof records, and public claim boundaries.
+
+`CONTROLLED_TEST_VALIDATED` | `NOT_PUBLIC_SAFE` | `HO-DET-001` | `RENDERING_NOT_PROOF` | `HUMAN_REVIEW_REQUIRED`
+
+[hawkinsoperations.com](https://hawkinsoperations.com/) | [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/) | [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) | [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) | [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections)
 
 </div>
 
 ---
 
-## If You Are Reviewing This Org, Start Here
+## Reviewer Cockpit
 
-A 90-second reviewer path. Each row is a single click and what it answers.
+Five reviewer routes. The route changes how to inspect the system; it does not change the proof state.
 
-| # | Click | What it answers |
-|:---:|---|---|
-| 01 | [`START_HERE.md`](./START_HERE.md) | What this org is and how to read it |
-| 02 | [Control Status Matrix](../governance/CONTROL_STATUS_MATRIX.md) | Which review gates are enforced today |
-| 03 | [Cross-Repo Promotion Map](../governance/CROSS_REPO_PROMOTION_MAP.md) | How work moves between truth surfaces |
-| 04 | [HO-DET-001 Proof Record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) | The flagship review path and its current ceiling |
-| 05 | [hawkinsoperations.com](https://hawkinsoperations.com/) | Public rendering only - not proof |
+| Route | Time | What to inspect | Start |
+|---|---:|---|---|
+| Hiring manager | 3 min | What the system is, what is proven, and what remains blocked. | [hawkinsoperations.com](https://hawkinsoperations.com/) |
+| Detection engineer | 10 min | Detection source, validation scope, and the HO-DET-001 proof path. | [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) |
+| SOC automation lead | 10 min | Case packet flow, deterministic checks, CI boundaries, and runtime-contract separation. | [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) |
+| AI governance reviewer | 10 min | Where AI supports labor and where human review authorizes claims. | [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) |
+| Public rendering reviewer | 2 min | Public presentation and reviewer navigation only; rendering does not create proof. | [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/) |
 
----
-
-## Reviewer Routes
-
-<table>
-<tr>
-<td width="33%" valign="top">
-
-### Executive Route
-**For:** security leads and nontechnical reviewers scanning for credibility.
-
-Read the doctrine, the public boundary table, and the architecture diagram. That is enough to decide whether to route this to a technical reviewer.
-
-_Time: ~3 minutes._
-
-</td>
-<td width="33%" valign="top">
-
-### Technical Route
-**For:** detection engineers, platform engineers, SOC automation leads.
-
-Open [`hawkinsoperations-detections`](https://github.com/HawkinsOperations/hawkinsoperations-detections) for source, [`hawkinsoperations-validation`](https://github.com/HawkinsOperations/hawkinsoperations-validation) for tests and fixtures, and [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) for the current claim ceiling. Runtime contracts remain an internal platform route unless explicitly published.
-
-_Time: ~15 minutes._
-
-</td>
-<td width="34%" valign="top">
-
-### Proof Route
-**For:** reviewers who want to verify, not browse.
-
-Open [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) and read the [HO-DET-001 record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md). Confirm the claim ceiling, the evidence chain, and the review gate before treating anything here as more than rendering.
-
-_Time: ~10 minutes._
-
-</td>
-</tr>
-</table>
+Website/GitHub rendering is not proof. Public surfaces route reviewers to proof records.
 
 ---
 
-## Architecture: How a Claim Earns Its Way to the Public Surface
+## Artifact Machine
 
-```mermaid
-flowchart LR
-    AI[AI Support Output]
-    A[Detection Source]
-    B[Validation]
-    C[Runtime Contract]
-    D[Signal Evidence]
-    E{Proof Record}
-    F[Public Rendering]
-    V[Deterministic Verification]
-    R[Human Review Gate]
+Eight stages. One direction. Generated work can enter the machine; only authorized proof can leave it as public wording.
 
-    AI -. feeds .-> A
-    AI -. feeds .-> B
-    AI -. feeds .-> C
-    A --> B --> C --> D
-    D --> E
-    V --> E
-    R --> E
-    E --> F
-```
+| Stage | Receipt | Owner | Current boundary |
+|---:|---|---|---|
+| 01 | Source | [`hawkinsoperations-detections`](https://github.com/HawkinsOperations/hawkinsoperations-detections) | Detection source exists for review. |
+| 02 | Validation | [`hawkinsoperations-validation`](https://github.com/HawkinsOperations/hawkinsoperations-validation) | Controlled-test validation can be inspected in its stated scope. |
+| 03 | Case packet | [`hawkinsoperations-validation`](https://github.com/HawkinsOperations/hawkinsoperations-validation) -> [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Case packets are produced and validated in validation, then cited and recorded by proof. |
+| 04 | AI support | Scoped labor only | AI can draft, scaffold, summarize, and assist; AI cannot promote claims. |
+| 05 | Verifier | Validation/proof checks | Deterministic checks protect the stated boundary where they are wired. |
+| 06 | CI | Repo workflows | CI is a checked gate only for its exact configured scope. |
+| 07 | Proof record | [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Proof records state the ceiling, linked routes, and blocked claims. |
+| 08 | Public boundary | [`hawkinsoperations-website`](https://github.com/HawkinsOperations/hawkinsoperations-website) and `.github` | Public surfaces render reviewed wording; they do not author proof. |
 
-AI support output feeds source, validation, and runtime work - it does not authorize promotion. Deterministic verification and human review are required gates before a proof record can support public wording. Public rendering is downstream of proof and cannot create it. Public ceiling remains `CONTROLLED_TEST_VALIDATED`.
+Current public ceiling: `CONTROLLED_TEST_VALIDATED`.
 
 ---
 
-## Repo Relationship Map
+## HO-DET-001 Flagship Proof Path
 
-```mermaid
-flowchart LR
-    GH[.github]
-    D[detections]
-    V[validation]
-    P[platform]
-    PR[proof]
-    W[website]
+HO-DET-001 is the artifact reviewers can trace end to end without accepting a stronger public claim.
 
-    GH -. reviewer routing .-> D
-    GH -. reviewer routing .-> PR
-    D --> V --> P --> PR --> W
-```
-
-Six repos exist because six truth surfaces need to stay separable. `.github` is orthogonal - it routes reviewers; it does not sit in the claim chain. The other five repos form the linear path a claim must walk before it can appear on a public surface.
-
----
-
-## Six-Surface Truth Flow
-
-| Surface | Owns | Does not own |
+| Receipt | Review route | What it supports |
 |---|---|---|
-| **Source** | Detection logic, hypotheses, rule definitions | Test pass, runtime fit, public wording approval |
-| **Validation** | Tests, fixtures, deterministic checks against source | Runtime behavior, signal observation |
-| **Runtime** | Contracts, integration boundaries, interface guarantees | Proof of live observation, public-safe status |
-| **Signal** | Runtime evidence candidates, only when captured and scoped | Source correctness, claim ceiling decisions |
-| **Evidence** | Proof records, claim ceilings, review attestations | Source authorship, public presentation |
-| **Public Rendering** | Website and GitHub presentation | Proof of any kind |
+| Source | [Detection source repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) | The detection source exists under version control. |
+| Validation | [Validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) | Controlled positive and negative test scope can be inspected. |
+| Case packet | [Validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) and [Proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Case packets are produced/validated in validation and cited/recorded by proof. |
+| Proof record | [HO-DET-001 proof record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) | The current public ceiling and blocked claims are recorded. |
+| Public rendering | [HO-DET-001 public route](https://hawkinsoperations.com/proof/ho-det-001/) | Reviewer navigation only; rendering does not create proof. |
 
-Public rendering cannot create proof. It can only present wording that is supported by proof records and review.
+Public proof ceiling remains `CONTROLLED_TEST_VALIDATED`. Public-safe status remains `NOT_PUBLIC_SAFE`.
+
+---
+
+## Proof Pack 001
+
+Proof Pack 001 is the planned reviewer package for HO-DET-001. It is release-prepared only until an official GitHub tag, release, and assets exist in `hawkinsoperations-proof`.
+
+| Item | Current public status |
+|---|---|
+| Package purpose | Reviewer package for tracing HO-DET-001 source, validation, case packet, proof record, and public boundary. |
+| Official release | Not claimed in this profile. |
+| Release assets | Not claimed in this profile. |
+| Public ceiling | `CONTROLLED_TEST_VALIDATED` |
+| Public-safe status | `NOT_PUBLIC_SAFE` |
+
+Do not treat planned packaging language as official release proof.
+
+---
+
+## Claim Firewall
+
+Public wording passes through boundary review before it ships. Blocked terms stay visible because they describe what this surface does not assert.
+
+Blocked unless separately promoted and approved:
+
+`public-safe` | `production-ready` | `fleet-wide` | `live enterprise deployment` | `autonomous SOC` | `AI-approved disposition` | `analyst-approved disposition` | `runtime-active public proof` | `signal-observed public proof` | `evidence-linked public proof` | `live Splunk public proof` | `Cribl-routed public proof` | `Wazuh-routed public proof` | `AWS-live proof` | `customer-ready product` | `sold product` | `enterprise deployment`
+
+Allowed public boundary for this profile:
+
+| Field | Current value |
+|---|---|
+| Flagship path | `HO-DET-001` |
+| Public proof ceiling | `CONTROLLED_TEST_VALIDATED` |
+| Public-safe status | `NOT_PUBLIC_SAFE` |
+| Surface mode | `RENDERING_NOT_PROOF` |
+| Promotion authority | `HUMAN_REVIEW_REQUIRED` |
+| Runtime-active public proof | `BLOCKED` |
+| Signal-observed public proof | `BLOCKED` |
+| Evidence-linked public proof | `BLOCKED` |
+| Production / fleet / autonomous claim | `BLOCKED` |
+
+---
+
+## Six Truth Surfaces
+
+Each surface supports its own claims, nothing more.
+
+| Surface | Supports | Does not assert |
+|---|---|---|
+| Source truth | A source artifact exists and can be reviewed. | Deployment, runtime behavior, signal observation, or public proof. |
+| Validation truth | A deterministic validation process passed inside its stated scope. | Runtime operation, public signal, or external-use authorization. |
+| Runtime truth | A control or detection is active in a runtime environment when runtime evidence is reviewed. | Signal observation, evidence linkage, or public-safe proof. |
+| Signal truth | A bounded signal was observed in a stated context when signal evidence is reviewed. | Fleet scope, production readiness, or public-safe status. |
+| Evidence truth | A preserved artifact supports a specific bounded claim. | Claims outside the evidence boundary. |
+| Public rendering | Website and GitHub presentation of reviewed routes and wording. | Proof of any kind. |
+
+Promotion is upward and gated. Repo source, runtime state, signal observation, evidence linkage, website rendering, and public proof do not inherit authority from one another.
+
+```mermaid
+flowchart LR
+    A[Source] --> B[Validation]
+    B --> C[Case packet]
+    C --> D[Proof record]
+    D --> E[Public boundary]
+    F[AI support] -. labor only .-> A
+    F -. labor only .-> B
+    G[Human review] --> D
+    H[Deterministic checks] --> D
+    E -. rendering is not proof .-> I[Website / GitHub]
+```
+
+---
+
+## Repository Authority Map
+
+Six repositories. Three planes. Authority flows through scoped records, not presentation.
+
+| Plane | Repository | Authority | Boundary |
+|---|---|---|---|
+| Governance / routing | `.github` | Organization profile, reviewer routing, control summaries. | Routes reviewers; does not prove source, runtime, signal, evidence, or public proof. |
+| Authority chain | [`hawkinsoperations-detections`](https://github.com/HawkinsOperations/hawkinsoperations-detections) | Detection source logic and ownership trail. | Source does not prove validation or runtime. |
+| Authority chain | [`hawkinsoperations-validation`](https://github.com/HawkinsOperations/hawkinsoperations-validation) | Fixtures, validators, case packets, and deterministic checks. | Validation does not prove public runtime or signal state. |
+| Internal / private runtime contract | `hawkinsoperations-platform` | Runtime contracts, interface boundaries, and non-promotional guardrails. | Internal/private runtime-contract route; not a public proof route and not public proof. |
+| Authority chain | [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Proof records, claim ceilings, evidence boundary records, and cited case packets. | Proof records do not publish private evidence or raise ceilings by presentation. |
+| Rendering | [`hawkinsoperations-website`](https://hawkinsoperations.com/) | Public reviewer navigation and rendered wording. | Rendering is not proof and cannot approve a claim. |
+
+Detections -> validation -> proof feeds the authority chain. `.github` routes reviewers. `hawkinsoperations-platform` remains an internal/private runtime-contract route. The website renders receipts; it does not author them.
 
 ---
 
@@ -137,106 +163,74 @@ Public rendering cannot create proof. It can only present wording that is suppor
 | Flagship review path | `HO-DET-001` |
 | Public proof ceiling | `CONTROLLED_TEST_VALIDATED` |
 | Public-safe status | `NOT_PUBLIC_SAFE` |
-| Website / GitHub status | Rendering and reviewer routing only |
-| Runtime-active public claim | `BLOCKED` |
-| Signal-observed public claim | `BLOCKED` |
-| Production / fleet / autonomous claim | `BLOCKED` |
+| Website / GitHub status | `RENDERING_NOT_PROOF` |
+| Human review status | `HUMAN_REVIEW_REQUIRED` |
+| Runtime-active public proof | `BLOCKED` |
+| Signal-observed public proof | `BLOCKED` |
+| Evidence-linked public proof | `BLOCKED` |
+| Live Splunk / Cribl / Wazuh / AWS public proof | `BLOCKED` |
+| Production-ready / fleet-wide / autonomous claim | `BLOCKED` |
 
 Website/GitHub rendering is not proof.
 
----
+Current safe reading:
 
-## Repo Map
-
-<table>
-<tr>
-<td width="33%" valign="top">
-
-#### `.github`
-Org profile, reviewer routing, claim-tight wording, control labels.
-
-**Owns:** front-door presentation and reviewer entry points.
-**Does not prove:** source correctness, runtime fit, or any public claim.
-
-</td>
-<td width="33%" valign="top">
-
-#### [`hawkinsoperations-detections`](https://github.com/HawkinsOperations/hawkinsoperations-detections)
-Detection logic and hypotheses as source.
-
-**Owns:** rule definitions, source-level structure, detection authorship.
-**Does not prove:** that source passes tests, runs in any environment, or has been observed.
-
-</td>
-<td width="34%" valign="top">
-
-#### [`hawkinsoperations-validation`](https://github.com/HawkinsOperations/hawkinsoperations-validation)
-Tests, fixtures, and deterministic checks.
-
-**Owns:** validation artifacts and pass/fail outcomes against source.
-**Does not prove:** runtime fit or signal observation.
-
-</td>
-</tr>
-<tr>
-<td valign="top">
-
-#### `hawkinsoperations-platform` (internal / not public)
-Runtime contracts and integration boundaries.
-
-**Owns:** interface guarantees and runtime-side definitions.
-**Does not prove:** that contracts have produced public-safe observations. This route is not a public proof surface.
-
-</td>
-<td valign="top">
-
-#### [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof)
-Proof records, claim ceilings, review attestations.
-
-**Owns:** proof records, claim ceilings, and evidence-backed wording.
-**Does not prove:** anything beyond the recorded claim ceiling and linked evidence.
-
-</td>
-<td valign="top">
-
-#### [`hawkinsoperations-website`](https://hawkinsoperations.com/)
-Public rendering and reviewer routing.
-
-**Owns:** how authorized claims are presented to the public.
-**Does not prove:** anything. Rendering is not proof.
-
-</td>
-</tr>
-</table>
+- `CONTROLLED_TEST_VALIDATED` means the public ceiling stays at the controlled-test boundary recorded by proof.
+- `NOT_PUBLIC_SAFE` means private evidence material is not approved for public release.
+- `RENDERING_NOT_PROOF` means website and GitHub pages can route reviewers, but they cannot create evidence.
+- `HUMAN_REVIEW_REQUIRED` means AI output, CI, and rendering do not authorize promotion by themselves.
+- Case packets are produced and validated in `hawkinsoperations-validation` and cited or recorded by `hawkinsoperations-proof`.
+- Stronger wording requires reviewed evidence linkage, stale review, privacy review, and Raylee approval.
 
 ---
 
-## Current Scaling Track
+## Prior Operating Context
 
-Active work, not completed proof.
+HawkinsOps V1 / SignalFoundry metrics are prior operating context only. They are not current HawkinsOperations proof and do not raise the current HawkinsOperations ceiling.
 
-- **Front door polish** - org profile and reviewer entry points
-- **Cross-repo propagation block** - preventing claim drift between truth surfaces
-- **Proof records index** - discoverable map of authorized records
-- **Validation CI visibility** - surfacing pass/fail status without overstating it
-- **Next detection candidate** - selected only after validation and proof lanes are clean
+| Prior context | Boundary |
+|---|---|
+| 324,074 cases processed | Historical V1 / HawkinsOps context only. |
+| 200+ detections built | Historical V1 / HawkinsOps context only. |
+| 208/208 CI assertions | Historical V1 / HawkinsOps context only. |
+| 39.7% reduction measured | Historical V1 / HawkinsOps context only. |
+| 100% high-severity preservation | Historical V1 / HawkinsOps context only. |
+
+Current HawkinsOperations claims are bounded by source, validation, evidence, and the public-proof surface.
 
 ---
 
-## Real Control
+## Release / Discussion Links
+
+Official release and discussion links are not asserted here unless they are published.
+
+| Item | Link state |
+|---|---|
+| Proof Pack 001 release | Placeholder: not published in this profile. |
+| Reviewer discussion | Placeholder: not published in this profile. |
+| Proof repository | [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof) |
+| Public proof ledger | [hawkinsoperations.com/proof](https://hawkinsoperations.com/proof/) |
+
+---
+
+## Real Controls Rule
 
 Repo separation creates review boundaries. Real control comes from required review, deterministic verification, CI checks, proof records, and bounded public wording. The split is necessary; it is not sufficient. Treat the boundary as the artifact, not the architecture diagram.
 
 ---
 
+## Doctrine Closer
+
 <div align="center">
 
-## Doctrine
+## AI is labor. Governance is authority.
 
 **AI generates work. Evidence and human review authorize claims.**
 
 **Build loud. Verify hard. Claim tight. Ship receipts.**
 
-_Website/GitHub rendering is not proof._
+HawkinsOperations separates the work AI can accelerate from the gates that decide what the system is allowed to claim publicly.
+
+[Operator profile](https://github.com/raylee-hawkins) | [Proof ledger](https://hawkinsoperations.com/proof/) | [GitHub organization](https://github.com/HawkinsOperations)
 
 </div>


### PR DESCRIPTION
Summary:
- Reworks the HawkinsOperations org profile README into the reviewer-cockpit sequence used by hawkinsoperations.com.
- Adds scannable sections for reviewer routes, artifact machine, HO-DET-001 proof path, six truth surfaces, repository authority, claim firewall, public boundary, prior operating context, and doctrine.
- Preserves the current proof ceiling and public-safe boundary.

Proof boundary:
- Public proof ceiling remains CONTROLLED_TEST_VALIDATED.
- Public-safe status remains NOT_PUBLIC_SAFE.
- Website/GitHub rendering remains not proof.
- Runtime-active, signal-observed, production-ready, fleet-wide, autonomous SOC, AI-approved, analyst-approved, Cribl-routed, Wazuh-routed, and AWS-live claims remain blocked.
- hawkinsoperations-platform is treated as an internal/private runtime-contract route, not a public proof route.
- V1/HawkinsOps is kept as prior operating context only.

Validation:
- git diff --check -- profile/README.md
- git status --short --untracked-files=all
- forbidden label scan: TEST_VALIDATED_BOUNDED_SCOPE / TEST_VALIDATED_SYNTHETIC_SCOPE absent
- required label scan: CONTROLLED_TEST_VALIDATED / NOT_PUBLIC_SAFE present
- GitHub URL scan: complete, unwrapped Markdown links
- no dedicated local README/proof-boundary checker found in this repo