### PR TITLE
docs: tighten org front-door value and claim boundaries

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,19 +6,31 @@
 
 # HawkinsOperations
 
-**HawkinsOperations is a governed detection-engineering system and GitHub-native command center that lets AI accelerate security work while evidence and human review authorize claims.**
+**HawkinsOperations is a governed AI Security Operations control plane. AI can draft security work; deterministic validation, proof records, and human review authorize claims.**
 
 `CONTROLLED_TEST_VALIDATED` · `HO-DET-001` · `NOT_PUBLIC_SAFE` · `RENDERING_NOT_PROOF` · `HUMAN_REVIEW_REQUIRED`
 
-[Proof Pack 001 release](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) · [Proof Pack 001 Discussion](https://github.com/orgs/HawkinsOperations/discussions/32) · [hawkinsoperations.com](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections)
+[Start Here](START_HERE.md) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) · [website](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/)
 
 </div>
 
 ---
 
+## 10-second read
+
+- AI drafts security work.
+- Deterministic validation, proof records, and human review authorize claims.
+- Website/GitHub rendering is not proof.
+
+The system separates detection source, validation, platform contracts, proof records, governance routing, and public rendering so public claims cannot outrun evidence.
+
+**Current proof snapshot:** HO-DET-001 has source and controlled-test validation within the current public ceiling, Proof Pack 001 is a bounded reviewer route, the proof-owned ledger records 4 cases and 0 public-safe runtime cases, and the reviewer metrics route records 49 detection activity / controlled validation fires, 106 validation cases, 8 proof records, and 31 blocked claims.
+
+**Claim firewall:** runtime-active, signal-observed, production, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, and public-safe runtime claims remain blocked unless separately proven. Blocked claims are intentional controls, not failed features.
+
 ## HawkinsOperations Control Panel
 
-GitHub/org rendering is routing, not proof. Proof records live in [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof), and the current public ceiling remains `CONTROLLED_TEST_VALIDATED` unless a specific proof record says otherwise. Runtime, signal, public-safe, production, autonomous SOC, AI-approved disposition, and analyst-approved disposition claims remain blocked unless explicitly proven and approved.
+`.github` is the org command center for reviewer routing, truth boundaries, and claim controls. It does not create proof authority. Proof records live in [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof), and the current public ceiling remains `CONTROLLED_TEST_VALIDATED` unless a specific proof record says otherwise. Runtime, signal, public-safe, production, SOCaaS, autonomous SOC, AI-approved disposition, and analyst-approved disposition claims remain blocked unless explicitly proven and approved.
 
 | Command center view | Current route | Boundary |
 |---|---|---|

--- a/profile/START_HERE.md
+++ b/profile/START_HERE.md
@@ -2,13 +2,21 @@
 
 Start here if reviewing HawkinsOperations.
 
-HawkinsOperations is a governed detection-engineering system that lets AI accelerate security work while evidence and human review authorize claims.
+HawkinsOperations is a governed AI Security Operations control plane. AI can draft security work; deterministic validation, proof records, and human review authorize claims.
+
+The system separates detection source, validation, platform contracts, proof records, governance routing, and public rendering so public claims cannot outrun evidence.
+
+- AI drafts security work.
+- Validation, proof records, and human review authorize claims.
+- Website/GitHub rendering is not proof.
 
 The enterprise AI failure mode is that AI-generated output becomes a public claim, analyst conclusion, operational action, security disposition, or executive truth before evidence and human review authorize it. HawkinsOperations is built to prevent that promotion path.
 
+Current public proof is intentionally bounded. Runtime-active, signal-observed, production, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, and public-safe runtime claims remain blocked unless separately proven. Blocked claims are a claim firewall, not failed features.
+
 HawkinsOperations separates source, validation, runtime, signal, evidence, and public-claim truth. Each truth surface has a different owner and promotion gate.
 
-Website content is rendering only. Repository source proves source existence only.
+Website content and GitHub rendering are routing only. Repository source proves source existence only.
 
 HO-DET-001 current public repo proof level: CONTROLLED_TEST_VALIDATED.
 


### PR DESCRIPTION
## Summary
- Tightens the .github organization front door around the AI Security Operations control-plane framing.
- Adds a short reviewer-first 10-second read.
- Moves reviewer route links higher.
- Clarifies that validation, proof records, and human review authorize claims.
- Reinforces that Website/GitHub rendering is not proof and blocked claims are an intentional claim firewall.

## Scope
Changed only:
- profile/README.md
- profile/START_HERE.md

## Proof boundary
No proof state, runtime state, workflows, validators, detection logic, ledger files, proof records, website app code, or GitHub Projects were changed. Runtime-active, signal-observed, production, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, and public-safe runtime claims remain blocked unless separately proven.

## Validation
- git diff --check
- private/local path scan
- patent-pending scan
- promoted-claim context scan
- blocked-claim wording scan
- python scripts/verify-command-center-invariants.py
- changed-file scope gate