### PR TITLE
Align org profile naming to Hoxline

### DIFF
--- a/architecture/REPO_AUTHORITY_MAP.md
+++ b/architecture/REPO_AUTHORITY_MAP.md
@@ -6,7 +6,7 @@ Control type: soft enforcement
 
 ## Purpose
 
-This map defines what each HawkinsOperations organization repository may own. It prevents source, validation, platform, proof, and website material from claiming another truth surface.
+This map defines what each HawkinsOperations organization repository may own. It prevents product, source, validation, platform, proof, website, and org-routing material from claiming another truth surface.
 
 No repository may claim another repository's authority. Repository source is not runtime truth. Website presentation is not proof.
 
@@ -14,8 +14,21 @@ Reviewer entry point: [START_HERE.md](../profile/START_HERE.md). Current control
 
 HOD-001 baseline validation/proof does not promote HO-DET-001.
 
-The canonical private HawkinsOperations Control Board is the private org Project #2 operating cockpit for current work visibility. Project #1 is not an active reviewer route and was not resolvable through the live ProjectV2 API during the current cleanup pass. The board is not a seventh repo, not proof authority, not merge authority, and not public-safe approval.
+The canonical private HawkinsOperations Control Board is the private org Project #2 operating cockpit for current work visibility. Project #1 is not an active reviewer route and was not resolvable through the live ProjectV2 API during the current cleanup pass. The board is not an eighth repo, not proof authority, not merge authority, and not public-safe approval.
 
+Total HawkinsOperations system repos remain seven:
+
+- `.github` = org routing
+- `hawkinsoperations-detections` = source truth
+- `hawkinsoperations-validation` = behavior truth
+- `hawkinsoperations-platform` = contracts/mechanics
+- `hawkinsoperations-proof` = proof records/claim ceilings
+- `hawkinsoperations-website` = public rendering
+- `aevumguard` = current Hoxline compatibility repo path
+
+No eighth repo may be added without explicit approval.
+
+Hoxline is a proof-bound claim control system for AI-assisted security work. Current repository path: HawkinsOperations/aevumguard. Product name: Hoxline by HawkinsOperations. Repository rename is not yet approved. Claim Firewall is the first internal Claim Authority capability inside Hoxline; it does not change proof authority, runtime truth, signal truth, public-safe status, or approval boundaries.
 ## Authority Summary
 
 | Repository | Authority plane | Owns | Boundary |
@@ -26,16 +39,18 @@ The canonical private HawkinsOperations Control Board is the private org Project
 | `hawkinsoperations-platform` | Contracts / orchestration / control logic | Runtime contracts, interface boundaries, and non-promotional guardrails. | Contracts do not prove public proof, production readiness, or current runtime state. |
 | `hawkinsoperations-proof` | Proof records / evidence truth | Proof records, claim ceilings, evidence boundary records, and cited case packets. | Proof records do not publish raw private evidence or raise ceilings by presentation. |
 | `hawkinsoperations-website` | Public rendering only | Public reviewer navigation and rendered wording. | Rendering is not proof and cannot approve a claim. |
+| `aevumguard` | Product / front door | Hoxline product surface and Claim Authority capabilities, starting with Claim Firewall. | Product framing does not prove runtime, signal, evidence, public-safe status, production readiness, or approval. |
 
 ## Command Center Operating Surfaces
 
 | Surface | Route | Owns | Does not own |
 | --- | --- | --- | --- |
 | Organization front door | [profile/README.md](../profile/README.md) | High-level reviewer orientation and demo routing. | Proof, runtime, signal, or public-safe approval. |
+| Product front door | [aevumguard](https://github.com/HawkinsOperations/aevumguard) | Hoxline product experience and Claim Authority capability surface. | Proof authority, runtime truth, signal truth, public-safe approval, or repo expansion approval. |
 | Reviewer start path | [profile/START_HERE.md](../profile/START_HERE.md) | First-click review sequence and claim-boundary reminders. | Stronger claim status than proof records allow. |
 | Operating cockpit | [private org Control Board route](https://github.com/orgs/HawkinsOperations/projects/2) | Current work visibility and queue coordination for the canonical private HawkinsOperations Control Board; Project #1 is not an active reviewer route. | Source truth, validation truth, runtime truth, signal truth, proof, public-safe status, merge approval, or project metadata authority. |
 | Proof ledger route | [Lifetime Case Ledger public summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/lifetime-case-ledger-v1-public-summary.json) | Bounded count summary: 4 events, 4 cases, 0 public-safe cases, 0 closed cases. | Runtime activity, signal observation, public proof, public-safe runtime proof, case closure, or disposition authority. |
-| Clone-runnable proof chain | [REPRODUCIBLE_REVIEWER_PATH.md](REPRODUCIBLE_REVIEWER_PATH.md) | Source-controlled inspection steps across all six repos. | Private runtime access, evidence export, public-safe promotion, or GitHub settings changes. |
+| Clone-runnable proof chain | [REPRODUCIBLE_REVIEWER_PATH.md](REPRODUCIBLE_REVIEWER_PATH.md) | Source-controlled inspection steps across all seven repos. | Private runtime access, evidence export, public-safe promotion, GitHub settings changes, or product proof promotion. |
 
 ## Public Readiness Summary
 
@@ -47,6 +62,7 @@ The canonical private HawkinsOperations Control Board is the private org Project
 | `hawkinsoperations-platform` | Platform architecture, stack truth tracking, and environment boundary documentation. | Detection proof, public proof, sensitive runtime exports, private host details. | Architecture-oriented until runtime evidence is reviewed. | Platform docs prove current deployment state. |
 | `hawkinsoperations-proof` | Proof contracts, evidence indexes, public-safe records, and claim linkage structure. | Raw private evidence publication, runtime operation, source ownership for other repos. | Proof-oriented only for reviewed and scoped records. | Evidence-linked material is automatically public-safe. |
 | `hawkinsoperations-website` | Public rendering of approved content. | Source truth, runtime truth, evidence truth, claim approval. | Rendering-oriented after public claim review. | Website presentation proves a claim by itself. |
+| `aevumguard` | Current Hoxline compatibility repo path and Claim Authority capability UX. | Proof authority, runtime status, signal observation, public-safe approval, or repo expansion. | Product-oriented until proof records approve stronger claims. | A product page or capability label proves a claim by itself. |
 
 ## Cross-Repository Rules
 
@@ -56,6 +72,8 @@ The canonical private HawkinsOperations Control Board is the private org Project
 - Signal claims require observed telemetry, alert, log, or output context.
 - Evidence claims require preserved and linked support.
 - Public claims require public claim review and approval.
+- Claim Firewall remains an internal Hoxline Claim Authority capability and must not be framed as a separate HawkinsOperations product repo.
+- No eighth repo may be added without explicit approval.
 
 ## Blocked Organization-Level Claims
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 
 `CONTROLLED_TEST_VALIDATED` · `HO-DET-001` · `NOT_PUBLIC_SAFE` · `RENDERING_NOT_PROOF` · `HUMAN_REVIEW_REQUIRED`
 
-[Start Here](START_HERE.md) · [Public Control Board](https://github.com/orgs/HawkinsOperations/projects/3) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) · [website](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/)
+[Start Here](START_HERE.md) · [Hoxline](https://github.com/HawkinsOperations/aevumguard) · [Public Control Board](https://github.com/orgs/HawkinsOperations/projects/3) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) · [website](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/)
 
 </div>
 
@@ -22,17 +22,19 @@ HawkinsOperations is a governed AI Security Operations and detection engineering
 
 AI accelerates drafting, triage reasoning, case-packet support, documentation, and automation planning. Validation, platform guardrails, proof records, and human review decide what becomes operational truth.
 
-## Product 001: Claim Firewall
+## Product: Hoxline by HawkinsOperations
 
-Claim Firewall blocks unsupported security claims before they ship.
+Hoxline is a proof-bound claim control system for AI-assisted security work.
 
-- Product page: https://hawkinsoperations.com/claim-firewall/
-- Repo: https://github.com/HawkinsOperations/claim-firewall
-- Release: v0.1.0
-- Announcement: https://github.com/orgs/HawkinsOperations/discussions/51
-- Proof ceiling: TOOL_FUNCTION_ONLY
+- Product route: https://hawkinsoperations.com/aevumguard/
+- Current repository path: https://github.com/HawkinsOperations/aevumguard
+- Compatibility note: Product name is Hoxline by HawkinsOperations. Repository rename is not yet approved.
+- Doctrine: AI is not the authority. Evidence is.
+- Proof ceiling: public routing clarity only; no proof promotion.
 
-Claim Firewall checks configured wording policy only. It does not prove detection behavior, runtime telemetry, signal observation, production deployment, public release approval, service availability, customer rollout, AI approval, analyst approval, or final human authorization.
+Hoxline separates AI output from evidence-bound claim authority. Claim Authority governs what can be claimed. Claim Firewall is the first internal Claim Authority capability inside Hoxline and blocks unsupported claims by checking configured wording policy only. ProofCards export the evidence boundary behind an approved claim.
+
+Claim Firewall does not prove detection behavior, runtime telemetry, signal observation, production deployment, public release approval, service availability, customer rollout, AI approval, analyst approval, or final human authorization.
 
 ## Current status sources
 
@@ -53,7 +55,7 @@ Current pipeline and ledger values live in their owning repositories and records
 | [Proof Pack 001](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) | Bounded reviewer release ZIP with SHA256 and verifier route for HO-DET-001. | Gives a reviewer one package to verify without private lab access. |
 | [Runtime Route Proof v1](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/maps/RUNTIME-ROUTE-PROOF-V1-REVIEWER-MAP.md) | Private-candidate Wazuh -> Cribl -> Splunk route summary and prerelease. | Preserves a runtime-route proof candidate without publishing raw private evidence or raising public proof status. |
 | [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) | Reviewer Metrics Pipeline v1 closeout snapshot and source record. | Reports reviewer-scale activity without turning validation activity into governed case truth. |
-| [Six-repo authority model](../architecture/REPO_AUTHORITY_MAP.md) | Detections own source, validation owns behavior, platform owns mechanics, proof owns claim ceilings, website renders, and `.github` routes. | Makes the system reviewable without allowing one repo or page to claim another truth surface. |
+| [Seven-repo authority model](../architecture/REPO_AUTHORITY_MAP.md) | Detections own source, validation owns behavior, platform owns mechanics, proof owns claim ceilings, website renders, `.github` routes, and `aevumguard` is the current Hoxline compatibility repo path. | Makes the system reviewable without allowing one repo or page to claim another truth surface. |
 
 ## Authority engines
 
@@ -84,7 +86,7 @@ Public Control Board: A public-safe project board showing Built, Proven, Blocked
 
 | Command center view | Current route | Boundary |
 |---|---|---|
-| Six-repo architecture | [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) | Repos own separate truth surfaces; no repo may claim another repo's authority. |
+| Seven-repo architecture | [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) | Repos own separate truth surfaces; no repo may claim another repo's authority. No eighth repo may be added without explicit approval. |
 | Proof chain | Detection source -> validation -> case packet -> proof record -> public rendering | Public rendering routes reviewers; it does not create proof. |
 | Truth surfaces | [Six truth surfaces](#six-truth-surfaces) | Source, validation, runtime, signal, evidence, and public rendering stay separate. |
 | Front-door/status proof ceiling | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` | Applies to command-center and ledger-status routing; HO-DET-001 proof records keep their own proof ceiling. |
@@ -283,7 +285,7 @@ flowchart LR
 
 ## Repository authority map
 
-Six repositories. Three planes. Authority flows through scoped records, not presentation.
+Seven repositories. Three planes. Authority flows through scoped records, not presentation. The current repository path remains `aevumguard` until a separate repository rename is approved.
 
 | Plane | Repository | Authority | Boundary |
 |---|---|---|---|
@@ -293,14 +295,15 @@ Six repositories. Three planes. Authority flows through scoped records, not pres
 | Internal / private runtime contract | `hawkinsoperations-platform` | Runtime contracts, interface boundaries, non-promotional guardrails. | Internal/private runtime-contract route; not a public proof route and not public proof. |
 | Authority chain | [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Proof records, claim ceilings, evidence boundary records, cited case packets. | Proof records do not publish private evidence or raise ceilings by presentation. |
 | Rendering | [`hawkinsoperations-website`](https://hawkinsoperations.com/) | Public reviewer navigation and rendered wording. | Rendering is not proof and cannot approve a claim. |
+| Product / front door | [`aevumguard`](https://github.com/HawkinsOperations/aevumguard) | Current Hoxline compatibility repo path and product surface. Claim Firewall is its first internal Claim Authority capability. | Product framing does not create proof authority, runtime truth, signal truth, public-safe status, or approval. |
 
-Detections → validation → proof feeds the authority chain. `.github` routes reviewers. `hawkinsoperations-platform` remains an internal/private runtime-contract route. The website renders receipts; it does not author them.
+Detections → validation → proof feeds the authority chain. `.github` routes reviewers. `hawkinsoperations-platform` remains an internal/private runtime-contract route. `aevumguard` is the current Hoxline compatibility repo path. The website renders receipts; it does not author them.
 
 ---
 
-## Claim firewall
+## Hoxline Claim Authority
 
-Public wording passes through boundary review before it ships. Blocked terms stay listed because they describe what this surface does not assert.
+Claim Authority governs what can be claimed. Claim Firewall blocks unsupported claims before public wording ships. Blocked terms stay listed because they describe what this surface does not assert.
 
 Blocked unless separately promoted and approved:
 

--- a/profile/START_HERE.md
+++ b/profile/START_HERE.md
@@ -2,9 +2,9 @@
 
 Start here if reviewing HawkinsOperations.
 
-HawkinsOperations is a governed AI Security Operations and detection engineering system built around source-controlled detection work, deterministic validation, platform contracts, proof records, reviewer releases, Windows/Linux runtime candidate lanes, ledger mechanics, and human-review gates.
+HawkinsOperations is a governed AI Security Operations and detection engineering system built around Hoxline, source-controlled detection work, deterministic validation, platform contracts, proof records, reviewer releases, Windows/Linux runtime candidate lanes, ledger mechanics, and human-review gates.
 
-The system separates detection source, validation, platform contracts, proof records, governance routing, and public rendering so public claims cannot outrun evidence.
+The system separates Hoxline product/front-door work, detection source, validation, platform contracts, proof records, governance routing, and public rendering so public claims cannot outrun evidence.
 
 - AI is labor; governance is authority.
 - AI can accelerate detection drafting, triage reasoning, case-packet support, documentation, and automation planning.
@@ -12,6 +12,10 @@ The system separates detection source, validation, platform contracts, proof rec
 - Validation, evidence records, proof boundaries, deterministic checks, and human review authorize operational truth.
 - Green CI is evidence for the checked scope, not approval.
 - Website/GitHub rendering is not proof.
+- Hoxline is a proof-bound claim control system for AI-assisted security work.
+- Hoxline separates AI output from evidence-bound claim authority.
+- Claim Authority governs what can be claimed. Claim Firewall blocks unsupported claims.
+- Current repository path: HawkinsOperations/aevumguard. Product name: Hoxline by HawkinsOperations. Repository rename is not yet approved.
 
 Start with the system signal, then inspect the receipts:
 
@@ -47,6 +51,7 @@ Windows and Linux private candidate lanes each produced one reviewed candidate. 
 | Proof | Claim authority | Proof records, claim ceilings, proof packs, reviewer maps, blocked claims, and releases decide what can be claimed. |
 | Website | Rendering | Public cockpit and reviewer routes, not proof authority. |
 | `.github` | Command center | Org front door, reviewer routing, and authority boundaries. |
+| Hoxline | Product front door | Main proof-bound claim control system for AI-assisted security work. Current repo path is `aevumguard`; Claim Firewall is its first internal Claim Authority capability. |
 
 Platform is the mechanical control layer: contracts, factory commands, ledger mechanics, case-packet schemas, runtime candidate gates, reviewer metrics state, and verifier scripts. It does not own proof promotion or public-safe runtime truth.
 
@@ -56,7 +61,7 @@ Proof is the public trust anchor: proof records, claim ceilings, Proof Pack 001,
 
 The enterprise AI failure mode is that AI-generated output becomes a public claim, analyst conclusion, operational action, security disposition, or executive truth before evidence and human review authorize it. HawkinsOperations is built to prevent that promotion path.
 
-Current public proof is intentionally bounded. Runtime-active, signal-observed, production, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, and public-safe runtime claims remain blocked unless separately proven. Blocked claims are a claim firewall, not failed features.
+Current public proof is intentionally bounded. Runtime-active, signal-observed, production, SOCaaS, autonomous SOC, AI-approved disposition, analyst-approved disposition, and public-safe runtime claims remain blocked unless separately proven. Blocked claims feed Hoxline Claim Authority; they are not failed features.
 
 HawkinsOperations separates source, validation, runtime, signal, evidence, and public-claim truth. Each truth surface has a different owner and promotion gate.
 
@@ -90,7 +95,7 @@ Public claims require reviewed wording, evidence linkage, stale review, and appr
 
 1. Open the [organization profile](./README.md) for the strongest current receipts.
 2. Open the [HO-DET-001 proof record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) and [Proof Pack 001 Release](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) to verify the flagship proof route and bounded reviewer release.
-3. Open the [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) to see which repo owns source, validation, platform, proof, website rendering, and org routing.
+3. Open the [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) to see which repo owns source, validation, platform, proof, website rendering, org routing, and the Hoxline product/front door.
 4. Open the [Platform ledger state manifest](https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/contracts/lifetime-case-ledger-v1-state-manifest.json) and [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) to verify the two separate number systems.
 5. Treat every website/GitHub page as routing unless the owning proof record supports the claim.
 
@@ -129,6 +134,7 @@ Runtime Route Proof v1 private-candidate boundary: the proof repo routes a revie
 | What is proven and what is blocked? | [Control Status Matrix](../governance/CONTROL_STATUS_MATRIX.md) |
 | Where are the standing control ledgers? | [Standing control registers](../governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md) |
 | Where are proof records? | [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof) |
+| Where is the main product/front-door repo? | [aevumguard](https://github.com/HawkinsOperations/aevumguard) |
 | Where is the Runtime Route Proof v1 private-candidate route? | [Reviewer map](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/maps/RUNTIME-ROUTE-PROOF-V1-REVIEWER-MAP.md) and [prerelease](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/runtime-route-proof-v1-private-candidate-2026-06-01) |
 | Where are validators and case packets? | [hawkinsoperations-validation](https://github.com/HawkinsOperations/hawkinsoperations-validation) |
 | Where is detection source? | [hawkinsoperations-detections](https://github.com/HawkinsOperations/hawkinsoperations-detections) |
@@ -147,6 +153,7 @@ Runtime Route Proof v1 private-candidate boundary: the proof repo routes a revie
 | `hawkinsoperations-platform` | Control mechanics, contracts, ledgers, append gates, runtime candidate lanes, and guardrail logic. | Public proof or production readiness. |
 | `hawkinsoperations-proof` | Claim authority, proof records, evidence boundaries, and claim ceilings. | Raw private evidence publication or claim expansion by presentation. |
 | `hawkinsoperations-website` | Public rendering and reviewer cockpit. | Proof authority. |
+| `aevumguard` | Current compatibility repo path for Hoxline by HawkinsOperations. Claim Firewall is the first internal Claim Authority capability inside Hoxline. | Proof authority, runtime state, signal state, public-safe approval, or an eighth-repo expansion path. |
 
 ### What is proven vs blocked
 


### PR DESCRIPTION
## Summary
Aligns the HawkinsOperations org front-door surfaces around Hoxline by HawkinsOperations as the working product name.

## Files changed
- profile/README.md
- profile/START_HERE.md
- rchitecture/REPO_AUTHORITY_MAP.md

## Naming truth
- Product name: Hoxline
- Public form: Hoxline by HawkinsOperations
- Parent authority brand: HawkinsOperations
- Doctrine: AI is not the authority. Evidence is.
- Claim Authority governs what can be claimed.
- Claim Firewall blocks unsupported claims.
- ProofCards export the evidence boundary behind an approved claim.

## Compatibility notes
- Current compatibility repo path remains HawkinsOperations/aevumguard.
- No repo rename, route rename, package rename, or schema URL change is included.
- Claim Firewall is preserved as an internal Hoxline Claim Authority capability, not a separate current product.

## Validation results
- git -C C:\Raylee\Repo\HawkinsOperations\.github diff --check passed with line-ending normalization warnings only.
- Root old-name leak verification found no current .github Aevum/AevumGuard/abandoned-name hits.

## Remaining old-name hits and why they remain
- None in this repo after excluding .git.

## Proof ceiling
Hoxline is the working product name in edited repo/public surfaces only. This does not establish trademark clearance, domain ownership, repository rename completion, route rename completion, production readiness, customer validation, or legal brand availability.
