### PR TITLE
fix: route org front door to Hoxline

### DIFF
--- a/architecture/REPO_AUTHORITY_MAP.md
+++ b/architecture/REPO_AUTHORITY_MAP.md
@@ -24,11 +24,11 @@ Total HawkinsOperations system repos remain seven:
 - `hawkinsoperations-platform` = contracts/mechanics
 - `hawkinsoperations-proof` = proof records/claim ceilings
 - `hawkinsoperations-website` = public rendering
-- `aevumguard` = current Hoxline compatibility repo path
+- `hoxline` = current Hoxline product/front-door repo
 
 No eighth repo may be added without explicit approval.
 
-Hoxline is a proof-bound claim control system for AI-assisted security work. Current repository path: HawkinsOperations/aevumguard. Product name: Hoxline by HawkinsOperations. Repository rename is not yet approved. Claim Firewall is the first internal Claim Authority capability inside Hoxline; it does not change proof authority, runtime truth, signal truth, public-safe status, or approval boundaries.
+Hoxline by HawkinsOperations is the current product/front-door repo and ProofOps control surface. Hoxline provides ProofOps control for the AI security era and governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim. Current repository path: HawkinsOperations/hoxline. AevumGuard is legacy/compatibility naming only. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline; it is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof.
 ## Authority Summary
 
 | Repository | Authority plane | Owns | Boundary |
@@ -39,17 +39,17 @@ Hoxline is a proof-bound claim control system for AI-assisted security work. Cur
 | `hawkinsoperations-platform` | Contracts / orchestration / control logic | Runtime contracts, interface boundaries, and non-promotional guardrails. | Contracts do not prove public proof, production readiness, or current runtime state. |
 | `hawkinsoperations-proof` | Proof records / evidence truth | Proof records, claim ceilings, evidence boundary records, and cited case packets. | Proof records do not publish raw private evidence or raise ceilings by presentation. |
 | `hawkinsoperations-website` | Public rendering only | Public reviewer navigation and rendered wording. | Rendering is not proof and cannot approve a claim. |
-| `aevumguard` | Product / front door | Hoxline product surface and Claim Authority capabilities, starting with Claim Firewall. | Product framing does not prove runtime, signal, evidence, public-safe status, production readiness, or approval. |
+| `hoxline` | Product / front door | Hoxline product surface and Claim Authority capabilities, starting with Claim Firewall. | Product framing does not prove runtime, signal, evidence, public-safe status, production readiness, or approval. |
 
 ## Command Center Operating Surfaces
 
 | Surface | Route | Owns | Does not own |
 | --- | --- | --- | --- |
 | Organization front door | [profile/README.md](../profile/README.md) | High-level reviewer orientation and demo routing. | Proof, runtime, signal, or public-safe approval. |
-| Product front door | [aevumguard](https://github.com/HawkinsOperations/aevumguard) | Hoxline product experience and Claim Authority capability surface. | Proof authority, runtime truth, signal truth, public-safe approval, or repo expansion approval. |
+| Product front door | [hoxline](https://github.com/HawkinsOperations/hoxline) | Hoxline product experience and Claim Authority capability surface. | Proof authority, runtime truth, signal truth, public-safe approval, or repo expansion approval. |
 | Reviewer start path | [profile/START_HERE.md](../profile/START_HERE.md) | First-click review sequence and claim-boundary reminders. | Stronger claim status than proof records allow. |
 | Operating cockpit | [private org Control Board route](https://github.com/orgs/HawkinsOperations/projects/2) | Current work visibility and queue coordination for the canonical private HawkinsOperations Control Board; Project #1 is not an active reviewer route. | Source truth, validation truth, runtime truth, signal truth, proof, public-safe status, merge approval, or project metadata authority. |
-| Proof ledger route | [Lifetime Case Ledger public summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/lifetime-case-ledger-v1-public-summary.json) | Bounded count summary: 4 events, 4 cases, 0 public-safe cases, 0 closed cases. | Runtime activity, signal observation, public proof, public-safe runtime proof, case closure, or disposition authority. |
+| Proof ledger route | [Lifetime Case Ledger public summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/lifetime-case-ledger-v1-public-summary.json) | Bounded count summary owned by proof records and platform manifests; this map does not copy changing counts. | Runtime activity, signal observation, public proof, public-safe runtime proof, case closure, or disposition authority. |
 | Clone-runnable proof chain | [REPRODUCIBLE_REVIEWER_PATH.md](REPRODUCIBLE_REVIEWER_PATH.md) | Source-controlled inspection steps across all seven repos. | Private runtime access, evidence export, public-safe promotion, GitHub settings changes, or product proof promotion. |
 
 ## Public Readiness Summary
@@ -62,7 +62,7 @@ Hoxline is a proof-bound claim control system for AI-assisted security work. Cur
 | `hawkinsoperations-platform` | Platform architecture, stack truth tracking, and environment boundary documentation. | Detection proof, public proof, sensitive runtime exports, private host details. | Architecture-oriented until runtime evidence is reviewed. | Platform docs prove current deployment state. |
 | `hawkinsoperations-proof` | Proof contracts, evidence indexes, public-safe records, and claim linkage structure. | Raw private evidence publication, runtime operation, source ownership for other repos. | Proof-oriented only for reviewed and scoped records. | Evidence-linked material is automatically public-safe. |
 | `hawkinsoperations-website` | Public rendering of approved content. | Source truth, runtime truth, evidence truth, claim approval. | Rendering-oriented after public claim review. | Website presentation proves a claim by itself. |
-| `aevumguard` | Current Hoxline compatibility repo path and Claim Authority capability UX. | Proof authority, runtime status, signal observation, public-safe approval, or repo expansion. | Product-oriented until proof records approve stronger claims. | A product page or capability label proves a claim by itself. |
+| `hoxline` | Current Hoxline product/front-door repo and Claim Authority capability UX. | Proof authority, runtime status, signal observation, public-safe approval, or repo expansion. | Product-oriented until proof records approve stronger claims. | A product page or capability label proves a claim by itself. |
 
 ## Cross-Repository Rules
 
@@ -72,7 +72,7 @@ Hoxline is a proof-bound claim control system for AI-assisted security work. Cur
 - Signal claims require observed telemetry, alert, log, or output context.
 - Evidence claims require preserved and linked support.
 - Public claims require public claim review and approval.
-- Claim Firewall remains an internal Hoxline Claim Authority capability and must not be framed as a separate HawkinsOperations product repo.
+- Claim Firewall remains the first Claim Authority enforcement capability inside Hoxline and must not be framed as the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, signal proof, or a separate HawkinsOperations product repo.
 - No eighth repo may be added without explicit approval.
 
 ## Blocked Organization-Level Claims

--- a/architecture/REPRODUCIBLE_REVIEWER_PATH.md
+++ b/architecture/REPRODUCIBLE_REVIEWER_PATH.md
@@ -6,11 +6,11 @@ Trust class: SOURCE_EXISTS after merge
 
 ## Purpose
 
-This path gives reviewers a clone-runnable route through the six HawkinsOperations repositories without treating `.github`, CI, proof, platform, or website rendering as stronger truth than they can support.
+This path gives reviewers a clone-runnable route through the seven HawkinsOperations repositories without treating `.github`, CI, proof, platform, Hoxline product framing, or website rendering as stronger truth than they can support.
 
 Website/GitHub rendering is not proof. Public surfaces route to proof records. Required checks matter only when they actually appear, run, and pass. Codex is AI labor, not human governance.
 
-## Clone All Six Repos
+## Clone All Seven Repos
 
 From an empty organization workspace:
 
@@ -23,6 +23,7 @@ git clone https://github.com/HawkinsOperations/hawkinsoperations-validation.git
 git clone https://github.com/HawkinsOperations/hawkinsoperations-platform.git
 git clone https://github.com/HawkinsOperations/hawkinsoperations-proof.git
 git clone https://github.com/HawkinsOperations/hawkinsoperations-website.git
+git clone https://github.com/HawkinsOperations/hoxline.git
 ```
 
 Expected sibling layout:
@@ -35,6 +36,7 @@ HawkinsOperations/
   hawkinsoperations-platform/
   hawkinsoperations-proof/
   hawkinsoperations-website/
+  hoxline/
 ```
 
 ## Reviewer Commands Available Today
@@ -98,13 +100,24 @@ python -B scripts\verify-ho-det-012-result-parity.py
 python -B scripts\scan-ho-det-012-claim-boundaries.py
 ```
 
-Report-only parity command, if the reviewer has all six sibling repos cloned:
+Report-only parity command, if the reviewer has all seven sibling repos cloned:
 
 ```powershell
 python -B scripts\verify_cross_repo_claim_parity.py --repo-root .. --report-only
 ```
 
 Report-only output is not fail-closed enforcement.
+
+### Hoxline Product / Claim Authority Plane
+
+```powershell
+cd ..\hoxline
+git status -sb
+python -B -m pytest -q tests
+python -B -m hoxline gauntlet verify --input examples\gauntlet\ho-det-001-full-loop-run-v0.json
+```
+
+Hoxline by HawkinsOperations is the product/front-door repo for ProofOps control. It governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline; it is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof.
 
 ### Platform Boundary and Visibility Plane
 

--- a/governance/COMMAND_CENTER_INVARIANTS.json
+++ b/governance/COMMAND_CENTER_INVARIANTS.json
@@ -25,7 +25,7 @@
     "command_center_proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY",
     "ledger_public_safe_status": "NOT_PUBLIC_SAFE",
     "reviewer_metrics_pipeline": "Reviewer metrics pipeline keeps Lifetime Governed Cases separate from detection activity, validation cases, proof records, blocked claims, and Project Board reconciliation status",
-    "reviewer_metrics_counts": "Lifetime Governed Cases 4; Detection Activity / controlled validation fire count 49; Validation Case Count 106; Proof Record Count 8; Blocked Claim Count 31",
+    "reviewer_metrics_counts": "Reviewer metrics values are authority-owned snapshots in proof/platform records; front-door text must route to those records instead of copying changing counts",
     "ho_det_001_public_ceiling": "CONTROLLED_TEST_VALIDATED",
     "runtime_signal_public_promotions": "runtime-active, signal-observed, evidence-linked public proof, public-safe, production-ready, fleet-wide, AWS-live, Cribl-routed, Wazuh-routed, autonomous SOC, AI-approved, AI-decided, analyst-approved, and live Splunk claims remain blocked unless separately proven and approved",
     "standing_controls": ".github#8 and .github#10 remain standing controls",

--- a/governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md
+++ b/governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md
@@ -156,9 +156,9 @@ Purpose: advances issue [#39](https://github.com/HawkinsOperations/.github/issue
 
 ## Reviewer Metrics Pipeline Reconciliation Receipt
 
-Purpose: gives reviewers a single repo-backed reconciliation row for the "big number without lying" metrics pipeline while preserving the strict Lifetime Case Ledger boundary.
+Purpose: gives reviewers a point-in-time repo-backed reconciliation row for the "big number without lying" metrics pipeline while preserving the strict Lifetime Case Ledger boundary. These values are a historical receipt snapshot, not current front-door authority; current values must be read from the owning platform, validation, and proof records.
 
-| Metric / status | Current bounded value | Owning source | Boundary |
+| Metric / status | Historical bounded value | Owning source | Boundary |
 | --- | --- | --- | --- |
 | Lifetime Governed Cases | 4 | `hawkinsoperations-platform` Lifetime Case Ledger state and `hawkinsoperations-proof` public ledger summary | Strict governed case count only; detection fires do not increase this number. |
 | Detection Activity / controlled validation fire count | 49 | `hawkinsoperations-validation` detection activity ledger | Controlled validation activity only; not runtime activity, signal observation, public proof, or governed case append. |

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 
 `CONTROLLED_TEST_VALIDATED` · `HO-DET-001` · `NOT_PUBLIC_SAFE` · `RENDERING_NOT_PROOF` · `HUMAN_REVIEW_REQUIRED`
 
-[Start Here](START_HERE.md) · [Hoxline](https://github.com/HawkinsOperations/aevumguard) · [Public Control Board](https://github.com/orgs/HawkinsOperations/projects/3) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) · [website](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/)
+[Start Here](START_HERE.md) · [Hoxline](https://github.com/HawkinsOperations/hoxline) · [Public Control Board](https://github.com/orgs/HawkinsOperations/projects/3) · [proof repo](https://github.com/HawkinsOperations/hawkinsoperations-proof) · [validation repo](https://github.com/HawkinsOperations/hawkinsoperations-validation) · [detections repo](https://github.com/HawkinsOperations/hawkinsoperations-detections) · [website](https://hawkinsoperations.com/) · [HO-DET-001 proof route](https://hawkinsoperations.com/proof/ho-det-001/)
 
 </div>
 
@@ -24,17 +24,19 @@ AI accelerates drafting, triage reasoning, case-packet support, documentation, a
 
 ## Product: Hoxline by HawkinsOperations
 
-Hoxline is a proof-bound claim control system for AI-assisted security work.
+Hoxline by HawkinsOperations is the current product/front-door repo for ProofOps control.
 
-- Product route: https://hawkinsoperations.com/aevumguard/
-- Current repository path: https://github.com/HawkinsOperations/aevumguard
-- Compatibility note: Product name is Hoxline by HawkinsOperations. Repository rename is not yet approved.
+- Product route: https://hawkinsoperations.com/hoxline/
+- Current repository path: https://github.com/HawkinsOperations/hoxline
+- Tagline: ProofOps control for the AI security era.
+- One-liner: Hoxline governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.
+- Compatibility note: AevumGuard is legacy/compatibility naming only. It is not the current product, current repo, or active front-door route.
 - Doctrine: AI is not the authority. Evidence is.
 - Proof ceiling: public routing clarity only; no proof promotion.
 
-Hoxline separates AI output from evidence-bound claim authority. Claim Authority governs what can be claimed. Claim Firewall is the first internal Claim Authority capability inside Hoxline and blocks unsupported claims by checking configured wording policy only. ProofCards export the evidence boundary behind an approved claim.
+Hoxline separates AI output from evidence-bound claim authority. Claim Authority governs what can be claimed. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline and blocks unsupported claims by checking configured wording policy only. ProofCards export the evidence boundary behind an approved claim.
 
-Claim Firewall does not prove detection behavior, runtime telemetry, signal observation, production deployment, public release approval, service availability, customer rollout, AI approval, analyst approval, or final human authorization.
+Claim Firewall is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof. It does not prove detection behavior, runtime telemetry, signal observation, production deployment, public release approval, service availability, customer rollout, AI approval, analyst approval, or final human authorization.
 
 ## Current status sources
 
@@ -55,7 +57,7 @@ Current pipeline and ledger values live in their owning repositories and records
 | [Proof Pack 001](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) | Bounded reviewer release ZIP with SHA256 and verifier route for HO-DET-001. | Gives a reviewer one package to verify without private lab access. |
 | [Runtime Route Proof v1](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/maps/RUNTIME-ROUTE-PROOF-V1-REVIEWER-MAP.md) | Private-candidate Wazuh -> Cribl -> Splunk route summary and prerelease. | Preserves a runtime-route proof candidate without publishing raw private evidence or raising public proof status. |
 | [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) | Reviewer Metrics Pipeline v1 closeout snapshot and source record. | Reports reviewer-scale activity without turning validation activity into governed case truth. |
-| [Seven-repo authority model](../architecture/REPO_AUTHORITY_MAP.md) | Detections own source, validation owns behavior, platform owns mechanics, proof owns claim ceilings, website renders, `.github` routes, and `aevumguard` is the current Hoxline compatibility repo path. | Makes the system reviewable without allowing one repo or page to claim another truth surface. |
+| [Seven-repo authority model](../architecture/REPO_AUTHORITY_MAP.md) | Detections own source, validation owns behavior, platform owns mechanics, proof owns claim ceilings, website renders, `.github` routes, and `hoxline` is the current product/front-door repo. | Makes the system reviewable without allowing one repo or page to claim another truth surface. |
 
 ## Authority engines
 
@@ -285,7 +287,7 @@ flowchart LR
 
 ## Repository authority map
 
-Seven repositories. Three planes. Authority flows through scoped records, not presentation. The current repository path remains `aevumguard` until a separate repository rename is approved.
+Seven repositories. Three planes. Authority flows through scoped records, not presentation. The current product/front-door repository is `hoxline`.
 
 | Plane | Repository | Authority | Boundary |
 |---|---|---|---|
@@ -295,9 +297,9 @@ Seven repositories. Three planes. Authority flows through scoped records, not pr
 | Internal / private runtime contract | `hawkinsoperations-platform` | Runtime contracts, interface boundaries, non-promotional guardrails. | Internal/private runtime-contract route; not a public proof route and not public proof. |
 | Authority chain | [`hawkinsoperations-proof`](https://github.com/HawkinsOperations/hawkinsoperations-proof) | Proof records, claim ceilings, evidence boundary records, cited case packets. | Proof records do not publish private evidence or raise ceilings by presentation. |
 | Rendering | [`hawkinsoperations-website`](https://hawkinsoperations.com/) | Public reviewer navigation and rendered wording. | Rendering is not proof and cannot approve a claim. |
-| Product / front door | [`aevumguard`](https://github.com/HawkinsOperations/aevumguard) | Current Hoxline compatibility repo path and product surface. Claim Firewall is its first internal Claim Authority capability. | Product framing does not create proof authority, runtime truth, signal truth, public-safe status, or approval. |
+| Product / front door | [`hoxline`](https://github.com/HawkinsOperations/hoxline) | Current Hoxline product/front-door repo and ProofOps control surface. Claim Firewall is its first internal Claim Authority enforcement capability. | Product framing does not create proof authority, runtime truth, signal truth, public-safe status, or approval. |
 
-Detections → validation → proof feeds the authority chain. `.github` routes reviewers. `hawkinsoperations-platform` remains an internal/private runtime-contract route. `aevumguard` is the current Hoxline compatibility repo path. The website renders receipts; it does not author them.
+Detections → validation → proof feeds the authority chain. `.github` routes reviewers. `hawkinsoperations-platform` remains an internal/private runtime-contract route. `hoxline` is the current Hoxline product/front-door repo. AevumGuard is legacy/compatibility naming only. The website renders receipts; it does not author them.
 
 ---
 

--- a/profile/START_HERE.md
+++ b/profile/START_HERE.md
@@ -12,25 +12,29 @@ The system separates Hoxline product/front-door work, detection source, validati
 - Validation, evidence records, proof boundaries, deterministic checks, and human review authorize operational truth.
 - Green CI is evidence for the checked scope, not approval.
 - Website/GitHub rendering is not proof.
-- Hoxline is a proof-bound claim control system for AI-assisted security work.
+- Hoxline by HawkinsOperations is the current product/front-door repo.
+- Hoxline provides ProofOps control for the AI security era.
+- Hoxline governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim.
 - Hoxline separates AI output from evidence-bound claim authority.
-- Claim Authority governs what can be claimed. Claim Firewall blocks unsupported claims.
-- Current repository path: HawkinsOperations/aevumguard. Product name: Hoxline by HawkinsOperations. Repository rename is not yet approved.
+- Doctrine: AI is not the authority. Evidence is.
+- Claim Authority governs what can be claimed. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline; it is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof.
+- Current repository path: HawkinsOperations/hoxline.
+- AevumGuard is legacy/compatibility naming only. It is not the current product, current repo, or active front-door route.
 
 Start with the system signal, then inspect the receipts:
 
 | Current operating signal | Value | Boundary |
 |---|---:|---|
-| Lifetime Governed Cases | 6 | Current strict platform ledger count; public-safe count remains 0 and closed-case count remains 0. |
-| Windows Runtime Collector candidates | 1 | Private candidate lane only. |
-| Linux Runtime Collector candidates | 1 | Private candidate lane only. |
-| Normalized append-ready candidates | 2 | Zero duplicates; only the approved appended rows became governed cases. |
-| Controlled validation activity fires | 49 | Validation activity, not governed cases or runtime signals. |
-| Validation cases | 106 | Controlled/reviewer activity scale, not production coverage. |
-| Proof records | 8 | Proof-record routing count, not public-safe approval. |
-| Blocked claims | 31 | Claim-control count, not missing functionality. |
+| Lifetime Governed Cases | See platform ledger state manifest | Current strict platform ledger count; public-safe and closed-case counts remain authority-owned by platform/proof records. |
+| Windows Runtime Collector candidates | See platform runtime-candidate records | Private candidate lane only. |
+| Linux Runtime Collector candidates | See platform runtime-candidate records | Private candidate lane only. |
+| Normalized append-ready candidates | See platform normalizer records | Candidate status does not become governed case truth without explicit approval and verifier gates. |
+| Controlled validation activity fires | See reviewer metrics summary | Validation activity, not governed cases or runtime signals. |
+| Validation cases | See reviewer metrics summary | Controlled/reviewer activity scale, not production coverage. |
+| Proof records | See reviewer metrics summary | Proof-record routing count, not public-safe approval. |
+| Blocked claims | See reviewer metrics summary | Claim-control count, not missing functionality. |
 
-Windows and Linux private candidate lanes each produced one reviewed candidate. The normalizer produced two append-ready candidates with zero duplicates. After explicit approval and verifier gates, both rows were appended as governed Lifetime Ledger cases, moving the strict ledger count from 4 to 6.
+Private candidate lanes and normalizer outputs are governed by platform-owned records. Candidate status does not create runtime truth, signal truth, public-safe proof, or governed case truth by being summarized here.
 
 ## First receipts
 
@@ -38,7 +42,7 @@ Windows and Linux private candidate lanes each produced one reviewed candidate. 
 |---|---|---|
 | [HO-DET-001 proof record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) | PowerShell EncodedCommand detection route, source, Splunk source, controlled validation, proof record, and public ceiling. | `CONTROLLED_TEST_VALIDATED`; runtime, signal, production, and public-safe claims remain blocked. |
 | [Proof Pack 001 Release](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) | Bounded reviewer ZIP, SHA256, and verifier route for HO-DET-001. | Reviewer release only; not public-safe runtime proof. |
-| [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) | Reviewer Metrics Pipeline v1 closeout snapshot: 49 controlled validation activity fires, 106 validation cases, 8 proof records, 31 blocked claims. | Activity metrics are not governed cases, runtime signals, or public-safe proof. |
+| [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) | Reviewer Metrics Pipeline v1 source record for controlled validation activity, validation cases, proof records, and blocked claims. | Activity metrics are not governed cases, runtime signals, or public-safe proof. |
 | [Runtime Route Proof v1 reviewer map](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/maps/RUNTIME-ROUTE-PROOF-V1-REVIEWER-MAP.md) | Private-candidate Wazuh -> Cribl -> Splunk route summary and prerelease. | `NOT_PUBLIC_SAFE`; not public runtime proof, production proof, or broad-ingestion proof. |
 
 ## Authority engines
@@ -51,7 +55,7 @@ Windows and Linux private candidate lanes each produced one reviewed candidate. 
 | Proof | Claim authority | Proof records, claim ceilings, proof packs, reviewer maps, blocked claims, and releases decide what can be claimed. |
 | Website | Rendering | Public cockpit and reviewer routes, not proof authority. |
 | `.github` | Command center | Org front door, reviewer routing, and authority boundaries. |
-| Hoxline | Product front door | Main proof-bound claim control system for AI-assisted security work. Current repo path is `aevumguard`; Claim Firewall is its first internal Claim Authority capability. |
+| Hoxline | Product front door | Hoxline by HawkinsOperations is the current product/front-door repo and ProofOps control surface. Claim Firewall is its first internal Claim Authority enforcement capability. |
 
 Platform is the mechanical control layer: contracts, factory commands, ledger mechanics, case-packet schemas, runtime candidate gates, reviewer metrics state, and verifier scripts. It does not own proof promotion or public-safe runtime truth.
 
@@ -110,9 +114,9 @@ Public claims require reviewed wording, evidence linkage, stale review, and appr
 7. If you are reviewing internal operating context, open the [private org Control Board route](https://github.com/orgs/HawkinsOperations/projects/2). Treat it as work coordination only, not proof, approval, runtime state, signal state, public-safe status, or merge authority. Project #1 is not an active reviewer route.
 8. Open the [Reproducible Reviewer Path](../architecture/REPRODUCIBLE_REVIEWER_PATH.md) only if you want clone-runnable inspection steps.
 
-Current governed ledger snapshot: the platform-owned Lifetime Case Ledger state manifest records 6 ledger events, 6 total cases, 0 public-safe cases, and 0 closed cases. Ledger status remains `NOT_PUBLIC_SAFE`; front-door/status proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`.
+Current governed ledger snapshot: the platform-owned Lifetime Case Ledger state manifest is authoritative for ledger events, total cases, public-safe cases, and closed cases. Ledger status remains `NOT_PUBLIC_SAFE`; front-door/status proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`.
 
-Current Reviewer metrics pipeline snapshot: Detection Activity / controlled validation fire count: 49; Validation Case Count: 106; Proof Record Count: 8; Blocked Claim Count: 31; Project Board reconciliation status: `REPO_BACKED_RECONCILIATION_PLAN_NO_PROJECT_MUTATION`.
+Current Reviewer metrics pipeline values live in the proof-owned reviewer metrics summary and related source records. This front door routes to those records instead of copying changing counts into public-front-door text. Project Board reconciliation status remains `REPO_BACKED_RECONCILIATION_PLAN_NO_PROJECT_MUTATION`.
 
 Reviewer metrics boundary: the current Lifetime Governed Cases number stays strict and comes from the platform-owned Lifetime Case Ledger route. Detection Activity / controlled validation fire count, Validation Case Count, Proof Record Count, and Blocked Claim Count are separate reviewer activity metrics and must not be counted as governed cases. Project Board reconciliation is repo-backed routing/status only; Project metadata is not proof authority and no GitHub Project mutation is performed by this pipeline.
 
@@ -134,7 +138,7 @@ Runtime Route Proof v1 private-candidate boundary: the proof repo routes a revie
 | What is proven and what is blocked? | [Control Status Matrix](../governance/CONTROL_STATUS_MATRIX.md) |
 | Where are the standing control ledgers? | [Standing control registers](../governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md) |
 | Where are proof records? | [hawkinsoperations-proof](https://github.com/HawkinsOperations/hawkinsoperations-proof) |
-| Where is the main product/front-door repo? | [aevumguard](https://github.com/HawkinsOperations/aevumguard) |
+| Where is the main product/front-door repo? | [hoxline](https://github.com/HawkinsOperations/hoxline) |
 | Where is the Runtime Route Proof v1 private-candidate route? | [Reviewer map](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/maps/RUNTIME-ROUTE-PROOF-V1-REVIEWER-MAP.md) and [prerelease](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/runtime-route-proof-v1-private-candidate-2026-06-01) |
 | Where are validators and case packets? | [hawkinsoperations-validation](https://github.com/HawkinsOperations/hawkinsoperations-validation) |
 | Where is detection source? | [hawkinsoperations-detections](https://github.com/HawkinsOperations/hawkinsoperations-detections) |
@@ -153,7 +157,8 @@ Runtime Route Proof v1 private-candidate boundary: the proof repo routes a revie
 | `hawkinsoperations-platform` | Control mechanics, contracts, ledgers, append gates, runtime candidate lanes, and guardrail logic. | Public proof or production readiness. |
 | `hawkinsoperations-proof` | Claim authority, proof records, evidence boundaries, and claim ceilings. | Raw private evidence publication or claim expansion by presentation. |
 | `hawkinsoperations-website` | Public rendering and reviewer cockpit. | Proof authority. |
-| `aevumguard` | Current compatibility repo path for Hoxline by HawkinsOperations. Claim Firewall is the first internal Claim Authority capability inside Hoxline. | Proof authority, runtime state, signal state, public-safe approval, or an eighth-repo expansion path. |
+| `hoxline` | Current product/front-door repo for Hoxline by HawkinsOperations. Claim Firewall is the first internal Claim Authority enforcement capability inside Hoxline. | Proof authority, runtime state, signal state, public-safe approval, or an eighth-repo expansion path. |
+| `aevumguard` | Legacy/compatibility naming only where older routes require it. | Current product identity, current repo identity, proof authority, runtime state, signal state, public-safe approval, or an eighth-repo expansion path. |
 
 ### What is proven vs blocked
 
@@ -161,8 +166,8 @@ Runtime Route Proof v1 private-candidate boundary: the proof repo routes a revie
 |---|---|
 | Proven within current public ceiling | HO-DET-001 source exists and controlled-test validation is recorded for the stated fixture scope. |
 | Route-safe | GitHub and website surfaces route reviewers to source, validation, and proof records. |
-| Ledger route-safe | The platform-owned Lifetime Case Ledger state manifest routes bounded current counts only: 6 events, 6 cases, 0 public-safe cases, 0 closed cases. |
-| Reviewer metrics route-safe | The reviewer metrics pipeline routes separate bounded numbers for Lifetime Governed Cases, Detection Activity / controlled validation fire count, Validation Case Count, Proof Record Count, Blocked Claim Count, and Project Board reconciliation status. |
+| Ledger route-safe | The platform-owned Lifetime Case Ledger state manifest routes bounded current ledger status without making this front door the authority for copied counts. |
+| Reviewer metrics route-safe | The reviewer metrics pipeline routes separate bounded values for Lifetime Governed Cases, Detection Activity / controlled validation fire count, Validation Case Count, Proof Record Count, Blocked Claim Count, and Project Board reconciliation status. |
 | Runtime route private-candidate route-safe | Runtime Route Proof v1 routes one private controlled Wazuh -> Cribl -> Splunk marker summary to proof records and a prerelease; it remains `NOT_PUBLIC_SAFE` and does not promote public-safe runtime proof, production SOC operation, autonomous SOC behavior, broad ingestion, AI-decided disposition, public publication approval, or Lifetime Governed Case mutation. |
 | Blocked | Runtime-active, signal-observed, public-safe runtime proof, production-ready, autonomous SOC, AI-approved disposition, analyst-approved disposition, Cribl-routed, Wazuh-routed, AWS-live, fleet-wide, and live Splunk firing claims. |
 

--- a/scripts/verify-command-center-invariants.py
+++ b/scripts/verify-command-center-invariants.py
@@ -38,6 +38,7 @@ REQUIRED_TEXT = {
         "Validation Case Count",
         "Proof Record Count",
         "Blocked Claim Count",
+        "HawkinsOperations/hoxline",
         "Project Board reconciliation status",
         "Project #1 is not an active reviewer route",
         "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY",
@@ -171,6 +172,10 @@ def check_required_text(errors: list[str]) -> None:
 
 def check_project_boundaries(all_text: str, errors: list[str]) -> None:
     required = [
+        "hoxline",
+        "Hoxline by HawkinsOperations",
+        "ProofOps control for the AI security era",
+        "AI is not the authority. Evidence is.",
         "Project #2",
         "canonical private HawkinsOperations Control Board",
         "Project #1 is not an active reviewer route",


### PR DESCRIPTION
## Summary

- Route HawkinsOperations org front-door Hoxline links to HawkinsOperations/hoxline.
- Demote AevumGuard to legacy/compatibility naming only.
- Demote Claim Firewall to the first Claim Authority enforcement capability inside Hoxline, not the product/platform/front-door repo/eighth repo/proof authority/runtime proof/signal proof.
- Update the repo authority map and reproducible reviewer path to show exactly seven repos including hoxline.
- Route changing metric values to owning platform/proof records instead of copying live counts into front-door text.

## Validation

- python -B scripts\verify-command-center-invariants.py
- git diff --check
- git status --short

## Proof ceiling

This PR changes routing/governance wording only. It does not create proof authority, runtime truth, signal truth, public-safe status, customer deployment, SOCaaS deployment, production readiness, AI-approved disposition, analyst-approved disposition, or merge authority.