### PR TITLE
[org] route reviewers to Hoxline one-command demo

### DIFF
--- a/architecture/REPRODUCIBLE_REVIEWER_PATH.md
+++ b/architecture/REPRODUCIBLE_REVIEWER_PATH.md
@@ -114,13 +114,14 @@ Report-only output is not fail-closed enforcement.
 cd ..\hoxline
 git status -sb
 python -B -m pytest -q tests
+python -B -m hoxline demo quickstart --output .hoxline\demo-runs\self-test --force
+python -B -m hoxline demo verify --input .hoxline\demo-runs\self-test\run-summary.json
 python -B -m hoxline gauntlet verify --input examples\gauntlet\ho-det-001-full-loop-run-v0.json
 ```
 
-Hoxline by HawkinsOperations is the product/front-door repo for ProofOps control. It governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline; it is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof.
+Hoxline by HawkinsOperations is the product/front-door repo for ProofOps control. The one-command reviewer demo is deterministic, local, and fixture-based; it routes reviewers through the Hoxline loop without publishing private evidence, mutating runtime systems, or promoting public proof. Hoxline governs how AI-assisted security work becomes tested, reviewed, blocked, or safe to claim. Claim Firewall is the first Claim Authority enforcement capability inside Hoxline; it is not the product, platform, front-door repo, an eighth repo, proof authority, runtime proof, or signal proof.
 
 ### Platform Boundary and Visibility Plane
-
 ```powershell
 cd ..\hawkinsoperations-platform
 git status -sb
@@ -210,4 +211,3 @@ This verifier proves only that checked command-center route files and invariant 
 ## Claim Boundary
 
 This reviewer path supports reproducible inspection of source-controlled contracts and deterministic checks. It does not prove runtime-active public proof, signal-observed public proof, public-safe proof, production-ready status, fleet-wide coverage, complete identity coverage, live IdP proof, live SIEM proof, live Splunk/Wazuh/Cribl/Security Onion proof, autonomous SOC, AI-approved disposition, analyst-approved disposition, customer-ready product, SOCaaS availability, or public evidence linkage unless the proof index supports it.
-

--- a/profile/START_HERE.md
+++ b/profile/START_HERE.md
@@ -97,14 +97,13 @@ Public claims require reviewed wording, evidence linkage, stale review, and appr
 
 ### 30-second reviewer path
 
-1. Open the [organization profile](./README.md) for the strongest current receipts.
-2. Open the [HO-DET-001 proof record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) and [Proof Pack 001 Release](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) to verify the flagship proof route and bounded reviewer release.
-3. Open the [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) to see which repo owns source, validation, platform, proof, website rendering, org routing, and the Hoxline product/front door.
-4. Open the [Platform ledger state manifest](https://github.com/HawkinsOperations/hawkinsoperations-platform/blob/main/contracts/lifetime-case-ledger-v1-state-manifest.json) and [Reviewer metrics summary](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/reviewer-metrics-pipeline-v1-summary.json) to verify the two separate number systems.
-5. Treat every website/GitHub page as routing unless the owning proof record supports the claim.
+1. Clone [Hoxline](https://github.com/HawkinsOperations/hoxline), then run `python -B -m hoxline demo quickstart` from the repo root.
+2. Read `.hoxline/demo-runs/<timestamp>/reviewer-pack.md`. The demo is deterministic, local, fixture-based, and not runtime proof.
+3. Open the [HO-DET-001 proof record](https://github.com/HawkinsOperations/hawkinsoperations-proof/blob/main/proof/records/HO-DET-001.md) and [Proof Pack 001 Release](https://github.com/HawkinsOperations/hawkinsoperations-proof/releases/tag/hawkinsoperations-proof-pack-001) to verify the flagship proof route and bounded reviewer release.
+4. Open the [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) to see which repo owns source, validation, platform, proof, website rendering, org routing, and the Hoxline product/front door.
+5. Treat every website/GitHub page as routing unless the owning proof record supports the claim. The Hoxline demo keeps `NOT_PUBLIC_SAFE`, requires human review, and does not promote public proof.
 
 ### 3-minute command-center path
-
 1. Complete the 30-second reviewer path above.
 2. Open the [Repository Authority Map](../architecture/REPO_AUTHORITY_MAP.md) to confirm which repo owns each truth surface.
 3. Open the [Control Status Matrix](../governance/CONTROL_STATUS_MATRIX.md) to confirm the current claim ceiling and blocked claims.


### PR DESCRIPTION
## Summary

Routes the org 30-second reviewer path to the merged Hoxline one-command demo:

- `python -B -m hoxline demo quickstart`
- `.hoxline/demo-runs/<timestamp>/reviewer-pack.md`
- adds the demo verify command to the reproducible Hoxline reviewer command block

## Boundary

This is reviewer routing only. It does not publish private evidence, mutate runtime systems, append or change the Lifetime Ledger, promote public proof, promote website proof, or claim public-safe runtime proof.

The routed demo is deterministic, local, fixture-based, and keeps:

- `public_safe_status`: `NOT_PUBLIC_SAFE`
- human review required
- no public proof promotion

## Validation

- `python scripts\verify-command-center-invariants.py` -> `COMMAND_CENTER_INVARIANTS=PASS`, `checked_files=18`
- `git diff --check` -> PASS
- Narrow boundary scan reviewed changed files; new wording is fixture-based routing and negative proof-boundary language only.